### PR TITLE
ZIOSuite extends ConcurrentEffectSuite

### DIFF
--- a/modules/zio/src/weaver/ziocompat/suites.scala
+++ b/modules/zio/src/weaver/ziocompat/suites.scala
@@ -9,7 +9,7 @@ import zio.interop.catz._
 import scala.util.Try
 
 abstract class MutableZIOSuite[Res <: Has[_]](implicit tag: Tag[Res])
-    extends EffectSuite[Task] {
+    extends ConcurrentEffectSuite[Task] {
 
   val sharedLayer: ZLayer[ZEnv, Throwable, Res]
 


### PR DESCRIPTION
This enables to parallelize a single zio test itself.
E.g. to use of scalacheck `MyTest extends SimpleZIOSuite  with Checkers[Task]`