### PR TITLE
Cross-suite resource sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 [![Build Status](https://cloud.drone.io/api/badges/disneystreaming/weaver-test/status.svg)](https://cloud.drone.io/disneystreaming/weaver-test)
 [![Latest version](https://index.scala-lang.org/disneystreaming/weaver-test/weaver-core/latest.svg?color=orange)](https://index.scala-lang.org/disneystreaming/weaver-test/weaver-core)
+[![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
+[![CLA assistant](https://cla-assistant.io/readme/badge/disneystreaming/weaver-test)](https://cla-assistant.io/disneystreaming/weaver-test)
+
 
 # Weaver-test
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,12 @@
 // shadow sbt-scalajs' crossProject and CrossType from Scala.js 0.6.x
 import sbtcrossproject.CrossPlugin.autoImport.{ crossProject, CrossType }
 
-addCommandAlias("ci",
-                ";project root ;versionDump; scalafmtCheckAll ;+clean ;+test:compile ;+test; docs/docusaurusCreateSite")
+addCommandAlias(
+  "ci",
+  ";project root ;versionDump; scalafmtCheckAll ;+clean ;+test:compile ;+test; docs/docusaurusCreateSite")
 
-addCommandAlias("release", ";project root ; +publishSigned; sonatypeBundleRelease")
+addCommandAlias("release",
+                ";project root ; +publishSigned; sonatypeBundleRelease")
 
 scalaVersion in ThisBuild := WeaverPlugin.scala213
 
@@ -50,7 +52,7 @@ lazy val coreJS  = core.js
 lazy val docs = project
   .in(file("modules/docs"))
   .enablePlugins(DocusaurusPlugin, MdocPlugin)
-  .dependsOn(coreJVM, scalacheckJVM, zioJVM)
+  .dependsOn(coreJVM, frameworkJVM, scalacheckJVM, zioJVM)
   .settings(
     moduleName := "docs",
     watchSources += (ThisBuild / baseDirectory).value / "docs",
@@ -72,7 +74,7 @@ lazy val framework = crossProject(JSPlatform, JVMPlatform)
   .settings(WeaverPlugin.simpleLayout)
   .settings(
     libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-time" % "2.0.0" % Test,
+      "io.github.cquiroz" %%% "scala-java-time"      % "2.0.0" % Test,
       "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.0.0" % Test
     ),
     scalacOptions in Test ~= (_ filterNot (_ == "-Xfatal-warnings")),
@@ -80,8 +82,8 @@ lazy val framework = crossProject(JSPlatform, JVMPlatform)
   )
   .jvmSettings(
     libraryDependencies ++= Seq(
-      "org.scala-sbt" % "test-interface"  % "1.0",
-      "org.scala-js"  %%% "scalajs-stubs" % "1.0.0" % "provided"
+      "org.scala-sbt"  % "test-interface" % "1.0",
+      "org.scala-js" %%% "scalajs-stubs"  % "1.0.0" % "provided"
     )
   )
   .jsSettings(

--- a/docs/global_resources.md
+++ b/docs/global_resources.md
@@ -1,0 +1,142 @@
+---
+id: global_resources
+title: Sharing resources across suites
+---
+
+## A word of warning
+
+This feature works **only on JVM** and violates the semantics of the [test-framework protocol](https://github.com/sbt/test-interface) that most Scala build tools (mill, sbt, bloop, etc) use. That protocol implies that all suites are supposed to run in isolation.
+
+Whilst the semantics cover most cases, it is sometimes really useful to share resources across suites, for efficiency reasons (especially if suites are run in parallel, which is decided by the build tool)
+
+Weaver-test provides this feature using what is very much a hack. At the time of writing this, the feature works with sbt, mill, bloop, but we cannot guarantee for it to work with all build tools.
+
+**Use at your own risk**
+
+When using weaver manually, outside of the build tool, with a standalone runner (we do provide one), please disregard this mechanism and use classic dependency injection and/or your own wits to share resources across suites.
+
+## Declaring global resources
+
+In order to declare global resources which suites will be able to share, weaver provide a `weaver.GlobalResourcesInit` interface that users can implement. This interface sports a method that takes a `weaver.GlobalResources.Write` instance, which contains semantics to store items indexed by types.
+
+NB : the implementations have to be static objects.
+
+```scala mdoc
+import weaver._
+
+import cats.effect.IO
+import cats.effect.Resource
+
+// note how this is a static object
+object SharedResources extends GlobalResourcesInit {
+  def sharedResources(store: GlobalResources.Write[IO]): Resource[IO, Unit] =
+    for {
+      foo <- Resource.pure[IO, String]("hello world!")
+      _   <- store.putR(foo)
+    } yield ()
+}
+```
+
+## Accessing global resources
+
+On the suite side, accessing the global resources happen via declaring a constructor on your suite that takes a single parameter of type `weaver.GlobalResources`.
+
+This item can be used to access the resources that were previously initialised and stored in the `GlobalResourcesInit`.
+
+
+```scala mdoc
+class SharingSuite(globalResources: GlobalResources) extends IOSuite {
+  type Res = String
+  def sharedResource: Resource[IO, String] =
+    globalResources.in[IO].getOrFailR[String]()
+
+  test("a stranger, from the outside ! ooooh") { sharedString =>
+    IO(expect(sharedString == "hello world!"))
+  }
+}
+
+class OtherSharingSuite(globalResources: GlobalResources)
+    extends IOSuite {
+  type Res = Option[Int]
+
+  // We didn't store an `Int` value in our `GlobalResourcesInit` impl
+  def sharedResource: Resource[IO, Option[Int]] =
+    globalResources.in[IO].getR[Int]()
+
+  test("oops, forgot something here") { sharedInt =>
+    IO(expect(sharedInt.isEmpty))
+  }
+}
+```
+
+## Lifecycle
+
+Weaver guarantees the following order :
+
+* All `weaver.GlobalResourcesInit` in current compile-unit are run. Because the interface they have access to is "write-only", the order in which these instances are used should not matter .
+* All suites are run in arbitrary order. Whether they run in parallel or not depends on the build-tool settings, not weaver.
+* Weaver then calls the finalisers of the resources created from the various `GlobalResourceInit` instances.
+
+This implies that **all resources declared in GlobalResourcesInit will remain alive/active until all tests have run**.
+
+## Regarding "testOnly" build tool commands
+
+Some build tools provide a "testOnly" (or equivalent) command that lets you test a single suite. Because of how weaver taps into the same detection mechanism build tools use to communicate suites to the framework, you should either :
+
+* pass your `weaver.GlobalResourcesInit` implementations to the `testOnly` command, alongside the suite you really want to run
+* ensure that suites can recover when the resource they need is not found in `weaver.GlobalResource`
+
+## Regarding global resource indexing
+
+### Runtime constraints
+
+The shared items are indexed via `weaver.ResourceTag`, a custom typeclass that has a default instance for based on `scala.reflect.ClassTag`. This implies that the default instance only works for types that are not subject to type-erasure.
+
+If the user wants to share resources which are subject to type-erasure (ie that have type parameters, such as `org.http4s.client.Client`), they have to provide an instance themselves, or alternatively use a monomorphic wrapper (which is not subject to type-erasure).
+
+```scala mdoc:fail
+import weaver._
+
+import cats.effect.IO
+import cats.effect.Resource
+
+// Class subject to type-erasure
+case class Foo[A](value : A)
+
+object FailingSharedResources extends GlobalResourcesInit {
+  def sharedResources(store: GlobalResources.Write[IO]): Resource[IO, Unit] =
+    store.putR(Foo("hello"))
+}
+```
+
+### Labelling
+
+On the two sides of (production and consumption) of the global resources, it is possible to label the resources with string values, to discriminate between several resources of the same.
+
+```scala mdoc
+import cats.implicits._
+
+object LabelSharedResources extends GlobalResourcesInit {
+  def sharedResources(store: GlobalResources.Write[IO]): Resource[IO, Unit] =
+    for {
+      _ <- store.putR(1, "one".some)
+      _ <- store.putR(2, "two".some)
+    } yield ()
+}
+
+class LabelSharingSuite(globalResources: GlobalResources)
+    extends IOSuite {
+
+  type Res = Int
+
+  // We didn't store an `Int` value in our `GlobalResourcesInit` impl
+  def sharedResource: Resource[IO, Int] = for {
+    one <- globalResources.in[IO].getOrFailR[Int]("one".some)
+    two <- globalResources.in[IO].getOrFailR[Int]("two".some)
+  } yield one + two
+
+  test("labels work") { sharedInt =>
+    IO(expect(sharedInt == 3))
+  }
+}
+```

--- a/modules/core/src-js/PlatformCompat.scala
+++ b/modules/core/src-js/PlatformCompat.scala
@@ -2,4 +2,7 @@ package weaver
 
 private[weaver] object PlatformCompat {
   val platform: Platform = Platform.JS
+
+  def getClassLoader(clazz: java.lang.Class[_]): ClassLoader =
+    new ClassLoader() {}
 }

--- a/modules/core/src-jvm/PlatformCompat.scala
+++ b/modules/core/src-jvm/PlatformCompat.scala
@@ -2,4 +2,7 @@ package weaver
 
 private[weaver] object PlatformCompat {
   val platform: Platform = Platform.JVM
+
+  def getClassLoader(clazz: java.lang.Class[_]): ClassLoader =
+    clazz.getClassLoader()
 }

--- a/modules/core/src/weaver/GlobalResources.scala
+++ b/modules/core/src/weaver/GlobalResources.scala
@@ -1,0 +1,139 @@
+package weaver
+
+import scala.reflect.ClassTag
+import scala.util.Try
+import cats.effect._
+import cats.implicits._
+import cats.MonadError
+import cats.effect.concurrent.Ref
+
+import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+import cats.Applicative
+
+/**
+ * Top-level instances of this trait are detected by the framework and used to manage
+ * the lifecycle of shared resources.
+ *
+ * The [[weaver.GlobalResources.Write]] store is a channel that lets you store
+ * resources (http/database clients) using some type-specific tags. We provide [[scala.reflect.ClassTag]]
+ * based implementation that works for that aren't subject to type-erasure (ie when a Scala type is
+ * equivalent to a JVM class)
+ *
+ * Stored resources can be retrieved in test suites, by having your suite sport a constructor
+ * that takes a [[GlobalResource]] instance.
+ */
+@EnableReflectiveInstantiation
+trait GlobalResourcesInit {
+  def sharedResources(store: GlobalResources.Write[IO]): Resource[IO, Unit]
+}
+
+trait GlobalResources {
+  def in[F[_]: LiftIO]: GlobalResources.Read[F]
+}
+
+object GlobalResources {
+
+  /**
+   */
+  trait Write[F[_]] {
+    def put[A](value: A, label: Option[String] = None)(
+        implicit rt: ResourceTag[A]): F[Unit]
+    def putR[A](value: A, label: Option[String] = None)(
+        implicit rt: ResourceTag[A],
+        F: Sync[F]): Resource[F, Unit] = Resource.liftF(put(value, label))
+  }
+
+  trait Read[F[_]] {
+    def get[A](label: Option[String] = None)(
+        implicit rt: ResourceTag[A]): F[Option[A]]
+
+    def getR[A](label: Option[String] = None)(
+        implicit F: Applicative[F],
+        rt: ResourceTag[A]): Resource[F, Option[A]] =
+      Resource.liftF(get[A](label))
+
+    def getOrFail[A](label: Option[String] = None)(
+        implicit F: MonadError[F, Throwable],
+        rt: ResourceTag[A]
+    ): F[A] =
+      get[A](label).flatMap[A] {
+        case Some(value) => F.pure(value)
+        case None =>
+          F.raiseError(GlobalResources.ResourceNotFound(label, rt.description))
+      }
+    def getOrFailR[A](label: Option[String] = None)(
+        implicit F: MonadError[F, Throwable],
+        rt: ResourceTag[A]
+    ): Resource[F, A] = Resource.liftF(getOrFail[A](label))
+
+  }
+
+  protected[weaver] val createMap: IO[Read[IO] with Write[IO]] =
+    Ref[IO]
+      .of(Map.empty[(Option[String], ResourceTag[_]), Any])
+      .map(new ResourceMap(_))
+
+  private class ResourceMap(
+      ref: Ref[IO, Map[(Option[String], ResourceTag[_]), Any]])
+      extends Read[IO]
+      with Write[IO] {
+    def put[A](value: A, label: Option[String])(
+        implicit rt: ResourceTag[A]): IO[Unit] =
+      ref.update(_ + ((label, rt) -> value))
+
+    def get[A](label: Option[String])(
+        implicit rt: ResourceTag[A]): IO[Option[A]] =
+      ref.get.map(_.get(label -> rt).flatMap(rt.cast))
+  }
+
+  case class ResourceNotFound(label: Option[String], typeDesc: String)
+      extends Throwable {
+    override def getMessage(): String =
+      s"Could not find a resource of type $typeDesc with label ${label.orNull}"
+  }
+}
+
+/**
+ * Rough type-tag, for which we provide a low effort instance based on classtags for classes that
+ * are not subject to type-erasure.
+ *
+ * Because this type is used as an index in a map, you ought to make sure it implements
+ * proper equals/hashCode methods
+ */
+trait ResourceTag[A] extends AnyRef {
+  def description: String
+  def cast(obj: Any): Option[A]
+}
+
+object ResourceTag extends LowPriorityImplicits
+
+protected[weaver] case class ClassBasedResourceTag[A](ct: ClassTag[A])
+    extends ResourceTag[A] {
+
+  def description: String       = ct.toString()
+  def cast(obj: Any): Option[A] = Try(obj.asInstanceOf[A]).toOption
+}
+
+trait LowPriorityImplicits {
+  implicit def classBasedInstance[A](implicit ct: ClassTag[A]): ResourceTag[A] =
+    ClassBasedResourceTag(ct)
+  @scala.annotation.implicitAmbiguous(
+    "\n\nCould not find an implicit ResourceTag instance for type ${F}[${A}]\n" +
+      "This is likely because ${F} is subject to type erasure. You can implement a ResourceTag manually " +
+      "or wrap the item you are trying to store/access, in some monomorphic case class that is not subject " +
+      "to type erasure\n\n")
+  implicit def notProvided1[F[_], A](
+      implicit ct: ClassTag[F[A]]): ResourceTag[F[A]] = ???
+  implicit def notProvided2[F[_], A](
+      implicit ct: ClassTag[F[A]]): ResourceTag[F[A]] = ???
+
+  @scala.annotation.implicitAmbiguous(
+    "\n\nCould not find an implicit ResourceTag instance for type ${HKF}[${F}]\n" +
+      "This is likely because ${HKF} is subject to type erasure. You can implement a ResourceTag manually " +
+      "or wrap the item you are trying to store/access, in some monomorphic case class that is not subject " +
+      "to type erasure\n\n")
+  implicit def notProvided3[HKF[_[_]], F[_]](
+      implicit ct: ClassTag[HKF[F]]): ResourceTag[HKF[F]] = ???
+  implicit def notProvided4[HKF[_[_]], F[_]](
+      implicit ct: ClassTag[HKF[F]]): ResourceTag[HKF[F]] = ???
+}

--- a/modules/core/src/weaver/Platform.scala
+++ b/modules/core/src/weaver/Platform.scala
@@ -3,6 +3,9 @@ package weaver
 sealed abstract class Platform(val name: String)
 
 object Platform {
+  def isJVM: Boolean = PlatformCompat.platform == JVM
+  def isJS: Boolean  = PlatformCompat.platform == JS
+
   case object JS  extends Platform("js")
   case object JVM extends Platform("jvm")
 }

--- a/modules/framework/src/weaver/framework/DogFood.scala
+++ b/modules/framework/src/weaver/framework/DogFood.scala
@@ -68,7 +68,8 @@ trait DogFood {
   // todo: ensure none of these contain side effects
   private def getTasks(suites: Seq[Fingerprinted]): Array[SbtTask] = {
     val tf     = new TestFramework
-    val runner = tf.runner(Array(), Array(), this.getClass.getClassLoader())
+    val cl     = PlatformCompat.getClassLoader(this.getClass())
+    val runner = tf.runner(Array(), Array(), cl)
     val taskDefs: Array[TaskDef] = suites.toArray.map { s =>
       new TaskDef(s.fullyQualifiedName,
                   s.fingerprint,

--- a/modules/framework/src/weaver/framework/TestFramework.scala
+++ b/modules/framework/src/weaver/framework/TestFramework.scala
@@ -8,7 +8,8 @@ class TestFramework extends BaseFramework {
   def name(): String = "weaver"
 
   def fingerprints(): Array[Fingerprint] = {
-    Array(TestFramework.ModuleFingerprint)
+    Array(TestFramework.GlobalResourcesFingerprint,
+          TestFramework.ModuleFingerprint)
   }
 
   def runner(
@@ -37,5 +38,25 @@ object TestFramework {
     val isModule                           = true
     def requireNoArgConstructor(): Boolean = true
     def superclassName(): String           = "weaver.BaseSuiteClass"
+  }
+
+  /**
+   * A fingerprint that searches only for classes extending [[weaver.EffectSuite]].
+   * that have a constructor that takes a single [[weaver.GlobalResources]] parameter.
+   */
+  object GlobalResourcesSharingFingerprint extends SubclassFingerprint {
+    val isModule                           = false
+    def requireNoArgConstructor(): Boolean = false
+    def superclassName(): String           = "weaver.BaseSuiteClass"
+  }
+
+  /**
+   * A fingerprint that searches only for singleton objects
+   * of type [[weaver.EffectSuite]].
+   */
+  object GlobalResourcesFingerprint extends SubclassFingerprint {
+    val isModule                           = true
+    def requireNoArgConstructor(): Boolean = true
+    def superclassName(): String           = "weaver.GlobalResourcesInit"
   }
 }

--- a/modules/framework/src/weaver/framework/TestFramework.scala
+++ b/modules/framework/src/weaver/framework/TestFramework.scala
@@ -57,7 +57,7 @@ object TestFramework {
 
   /**
    * A fingerprint that searches only for singleton objects
-   * of type [[weaver.EffectSuite]].
+   * of type [[weaver.GlobalResourcesInit]].
    */
   object GlobalResourcesFingerprint extends WeaverFingerprint {
     val isModule                           = true

--- a/modules/framework/src/weaver/framework/package.scala
+++ b/modules/framework/src/weaver/framework/package.scala
@@ -44,7 +44,6 @@ package object framework {
       name: String,
       globalResources: GlobalResources,
       loader: ClassLoader): IO[Any] = {
-    println(name)
     IO(Reflect.lookupInstantiatableClass(name, loader))
       .flatMap {
         case None =>

--- a/modules/framework/src/weaver/framework/package.scala
+++ b/modules/framework/src/weaver/framework/package.scala
@@ -1,9 +1,47 @@
 package weaver
 
 import cats.effect.IO
+import org.portablescala.reflect.Reflect
 
 package object framework {
 
   type DeferredLogger = (String, Event) => IO[Unit]
+
+  def loadModule(name: String, loader: ClassLoader): IO[Any] = {
+    val moduleName = name + "$"
+    IO(Reflect.lookupLoadableModuleClass(moduleName))
+      .flatMap {
+        case None =>
+          IO.raiseError(
+            new Exception(s"Could not load class $moduleName")
+              with scala.util.control.NoStackTrace
+          )
+        case Some(cls) => IO(cls.loadModule())
+      }
+  }
+
+  def makeInstance(
+      name: String,
+      globalResources: GlobalResources,
+      loader: ClassLoader): IO[Any] = {
+    IO(Reflect.lookupInstantiatableClass(name))
+      .flatMap {
+        case None =>
+          IO.raiseError(
+            new Exception(s"Could not load class $name")
+              with scala.util.control.NoStackTrace
+          )
+        case Some(cls) =>
+          IO(cls.getConstructor(classOf[GlobalResources])).flatMap {
+            case None =>
+              IO.raiseError(
+                new Exception(s"Could not find a constructor that takes a single weaver.GlobalResources parameter")
+                  with scala.util.control.NoStackTrace
+              )
+            case Some(cst) =>
+              IO(cst.newInstance(globalResources))
+          }
+      }
+  }
 
 }

--- a/modules/framework/src/weaver/framework/package.scala
+++ b/modules/framework/src/weaver/framework/package.scala
@@ -2,10 +2,30 @@ package weaver
 
 import cats.effect.IO
 import org.portablescala.reflect.Reflect
+import scala.util.control.NoStackTrace
 
 package object framework {
 
   type DeferredLogger = (String, Event) => IO[Unit]
+
+  def suiteFromModule(
+      qualifiedName: String,
+      loader: ClassLoader): IO[EffectSuite[Any]] =
+    castToSuite(loadModule(qualifiedName, loader))
+
+  def suiteFromGlobalResourcesSharingClass(
+      qualifiedName: String,
+      globalResources: GlobalResources,
+      loader: ClassLoader): IO[EffectSuite[Any]] =
+    castToSuite(makeInstance(qualifiedName, globalResources, loader))
+
+  private def castToSuite(io: IO[Any]): IO[EffectSuite[Any]] = io.flatMap {
+    case ref: EffectSuite[_] => IO.pure(ref)
+    case other =>
+      IO.raiseError {
+        new Exception(s"$other is not an effect suite") with NoStackTrace
+      }
+  }
 
   def loadModule(name: String, loader: ClassLoader): IO[Any] = {
     val moduleName = name + "$"
@@ -13,14 +33,13 @@ package object framework {
       .flatMap {
         case None =>
           IO.raiseError(
-            new Exception(s"Could not load class $moduleName")
-              with scala.util.control.NoStackTrace
+            new Exception(s"Could not load class $moduleName") with NoStackTrace
           )
         case Some(cls) => IO(cls.loadModule())
       }
   }
 
-  def makeInstance(
+  private def makeInstance(
       name: String,
       globalResources: GlobalResources,
       loader: ClassLoader): IO[Any] = {
@@ -34,10 +53,10 @@ package object framework {
         case Some(cls) =>
           IO(cls.getConstructor(classOf[GlobalResources])).flatMap {
             case None =>
-              IO.raiseError(
-                new Exception(s"Could not find a constructor that takes a single weaver.GlobalResources parameter")
-                  with scala.util.control.NoStackTrace
-              )
+              val message =
+                s"${cls.runtimeClass} is a class. It should either be an object, or have a constructor that takes a single parameter of type weaver.GlobalResources"
+              IO.raiseError(new Exception(message)
+                with scala.util.control.NoStackTrace)
             case Some(cst) =>
               IO(cst.newInstance(globalResources))
           }

--- a/modules/framework/src/weaver/framework/package.scala
+++ b/modules/framework/src/weaver/framework/package.scala
@@ -33,7 +33,8 @@ package object framework {
       .flatMap {
         case None =>
           IO.raiseError(
-            new Exception(s"Could not load class $moduleName") with NoStackTrace
+            new Exception(s"Could not load object $moduleName")
+              with NoStackTrace
           )
         case Some(cls) => IO(cls.loadModule())
       }
@@ -43,7 +44,8 @@ package object framework {
       name: String,
       globalResources: GlobalResources,
       loader: ClassLoader): IO[Any] = {
-    IO(Reflect.lookupInstantiatableClass(name))
+    println(name)
+    IO(Reflect.lookupInstantiatableClass(name, loader))
       .flatMap {
         case None =>
           IO.raiseError(

--- a/modules/framework/test/src-jvm/DogFoodTestsJVM.scala
+++ b/modules/framework/test/src-jvm/DogFoodTestsJVM.scala
@@ -1,0 +1,41 @@
+package weaver
+package framework
+package test
+
+import cats.effect.IO
+import cats.implicits._
+
+object DogFoodSuiteJVM extends SimpleIOSuite with DogFood {
+
+  // This tests the global resource sharing mechanism by running a suite that
+  // acquires a temporary file that gets created during global resource initialisation.
+  // The suite contains a test which logs the location of the file and fails to ensure logs
+  // get dispatched.
+  // We then recover the location of the file, which happens after the dogfooding framework finishes
+  // its run. At this point, the file should have been deleted by the global resource initialisation
+  // mechanism, which we test for.
+  simpleTest("global sharing suites") {
+    import Fingerprinted._
+    runSuites(moduleSuite(Meta.MutableSuiteTest),
+              sharingSuite[MetaJVM.TmpFileSuite],
+              globalInit(MetaJVM.GlobalStub)).flatMap {
+      case (logs, events) =>
+        val file = logs.collectFirst {
+          case LoggedEvent.Error(msg) if msg.contains("file:") =>
+            msg.split("file:")(1).trim()
+        }
+        for {
+          path <- file.liftTo[IO](new Exception("file log not found"))
+          file <- IO(new java.io.File(path))
+        } yield {
+          val errorCount =
+            events.count(_.status() != sbt.testing.Status.Success)
+          // The "GlobalStub" implements logic to clean up the file
+          // at the end of the test run.
+          // We're testing the file has indeed been cleaned up
+          expect(errorCount == 1) && expect(!file.exists())
+        }
+    }
+  }
+
+}

--- a/modules/framework/test/src-jvm/MetaJVM.scala
+++ b/modules/framework/test/src-jvm/MetaJVM.scala
@@ -1,0 +1,38 @@
+package weaver
+package framework
+package test
+
+import cats.effect._
+
+import java.io.File
+
+// The build tool will only detect and run top-level test suites. We can however nest objects
+// that contain failing tests, to allow for testing the framework without failing the build
+// because the framework will have ran the tests on its own.
+object MetaJVM {
+  object MutableSuiteTest extends MutableSuiteTest
+
+  object GlobalStub extends GlobalResourcesInit {
+    def sharedResources(store: GlobalResources.Write[IO]): Resource[IO, Unit] =
+      Resource.make(makeTmpFile)(deleteFile).flatMap { file =>
+        store.putR(file)
+      }
+
+    val makeTmpFile                    = IO(java.io.File.createTempFile("hello", ".tmp"))
+    def deleteFile(file: java.io.File) = IO(file.delete()).void
+  }
+
+  class TmpFileSuite(global: GlobalResources) extends IOSuite {
+    type Res = File
+    def sharedResource: Resource[IO, File] =
+      global.in[IO].getOrFailR[File]()
+
+    test("electric boo") { (file, log) =>
+      for {
+        _          <- log.info(s"file:${file.getAbsolutePath()}")
+        fileExists <- IO(file.exists())
+      } yield expect(fileExists) and failure("forcing logs dispatch")
+    }
+  }
+
+}

--- a/modules/framework/test/src/DogFoodTests.scala
+++ b/modules/framework/test/src/DogFoodTests.scala
@@ -2,6 +2,7 @@ package weaver
 package framework
 package test
 
+import cats.effect.IO
 import cats.implicits._
 import sbt.testing.Status
 import cats.data.Chain
@@ -189,6 +190,39 @@ object DogFoodSuite extends SimpleIOSuite with DogFood {
 
         expectEqual(expected, actual)
     }
+  }
+
+  // This tests the global resource sharing mechanism by running a suite that
+  // acquires a temporary file that gets created during global resource initialisation.
+  // The suite contains a test which logs the location of the file and fails to ensure logs
+  // get dispatched.
+  // We then recover the location of the file, which happens after the dogfooding framework finishes
+  // its run. At this point, the file should have been deleted by the global resource initialisation
+  // mechanism, which we test for.
+  simpleTest("global sharing suites") {
+    import Fingerprinted._
+    if (Platform.isJVM) {
+      runSuites(moduleSuite(Meta.MutableSuiteTest),
+                sharingSuite[Meta.TmpFileSuite],
+                globalInit(Meta.GlobalStub)).flatMap {
+        case (logs, events) =>
+          val file = logs.collectFirst {
+            case LoggedEvent.Error(msg) if msg.contains("file:") =>
+              msg.split("file:")(1).trim()
+          }
+          for {
+            path <- file.liftTo[IO](new Exception("file log not found"))
+            file <- IO(new java.io.File(path))
+          } yield {
+            val errorCount =
+              events.count(_.status() != sbt.testing.Status.Success)
+            // The "GlobalStub" implements logic to clean up the file
+            // at the end of the test run.
+            // We're testing the file has indeed been cleaned up
+            expect(errorCount == 1) && expect(!file.exists())
+          }
+      }
+    } else ignore("JVM only test")
   }
 
   private def multiLineComparisonReport(expectedS: String, actual: String) = {

--- a/modules/framework/test/src/DogFoodTests.scala
+++ b/modules/framework/test/src/DogFoodTests.scala
@@ -2,7 +2,6 @@ package weaver
 package framework
 package test
 
-import cats.effect.IO
 import cats.implicits._
 import sbt.testing.Status
 import cats.data.Chain
@@ -190,39 +189,6 @@ object DogFoodSuite extends SimpleIOSuite with DogFood {
 
         expectEqual(expected, actual)
     }
-  }
-
-  // This tests the global resource sharing mechanism by running a suite that
-  // acquires a temporary file that gets created during global resource initialisation.
-  // The suite contains a test which logs the location of the file and fails to ensure logs
-  // get dispatched.
-  // We then recover the location of the file, which happens after the dogfooding framework finishes
-  // its run. At this point, the file should have been deleted by the global resource initialisation
-  // mechanism, which we test for.
-  simpleTest("global sharing suites") {
-    import Fingerprinted._
-    if (Platform.isJVM) {
-      runSuites(moduleSuite(Meta.MutableSuiteTest),
-                sharingSuite[Meta.TmpFileSuite],
-                globalInit(Meta.GlobalStub)).flatMap {
-        case (logs, events) =>
-          val file = logs.collectFirst {
-            case LoggedEvent.Error(msg) if msg.contains("file:") =>
-              msg.split("file:")(1).trim()
-          }
-          for {
-            path <- file.liftTo[IO](new Exception("file log not found"))
-            file <- IO(new java.io.File(path))
-          } yield {
-            val errorCount =
-              events.count(_.status() != sbt.testing.Status.Success)
-            // The "GlobalStub" implements logic to clean up the file
-            // at the end of the test run.
-            // We're testing the file has indeed been cleaned up
-            expect(errorCount == 1) && expect(!file.exists())
-          }
-      }
-    } else ignore("JVM only test")
   }
 
   private def multiLineComparisonReport(expectedS: String, actual: String) = {

--- a/modules/framework/test/src/FSCompatTest.scala
+++ b/modules/framework/test/src/FSCompatTest.scala
@@ -12,7 +12,6 @@ abstract class FSCompatTest extends SimpleIOSuite {
   val absolutePath      = s"${pwd}/${relativePath}"
   val wrongAbsolutePath = s"/invalid/subpath/${fileName}"
 
-  println(s"wd: ${pwd}")
   test("best effort path of a relative path is that path") {
     val result = FSCompat.bestEffortPath(fileName.some, relativePath.some)
     expect(result == relativePath.some)

--- a/modules/framework/test/src/Global.scala
+++ b/modules/framework/test/src/Global.scala
@@ -4,13 +4,32 @@ package framework
 import cats.effect.IO
 import cats.effect.Resource
 
-object Global extends GlobalResourcesInit {
+object SharedResources extends GlobalResourcesInit {
   def sharedResources(store: GlobalResources.Write[IO]): Resource[IO, Unit] =
     for {
-      foo <- Resource.pure[IO, Int](1)
+      foo <- Resource.pure[IO, String]("hello world!")
       _   <- store.putR(foo)
     } yield ()
+}
 
-  case class Foo[F[_]](fint: F[Int])
+class ResourceSharingSuite(globalResources: GlobalResources) extends IOSuite {
+  type Res = String
+  def sharedResource: Resource[IO, String] =
+    globalResources.in[IO].getOrFailR[String]()
+
+  test("a stranger, from the outside ! ooooh") { sharedString =>
+    IO(expect(sharedString == "hello world!!"))
+  }
+}
+
+class OtherResourceSharingSuite(globalResources: GlobalResources)
+    extends IOSuite {
+  type Res = Option[Int]
+  def sharedResource: Resource[IO, Option[Int]] =
+    globalResources.in[IO].getR[Int]()
+
+  test("oops, forgot something here") { sharedInt =>
+    IO(expect(sharedInt.isEmpty))
+  }
 
 }

--- a/modules/framework/test/src/Global.scala
+++ b/modules/framework/test/src/Global.scala
@@ -18,7 +18,7 @@ class ResourceSharingSuite(globalResources: GlobalResources) extends IOSuite {
     globalResources.in[IO].getOrFailR[String]()
 
   test("a stranger, from the outside ! ooooh") { sharedString =>
-    IO(expect(sharedString == "hello world!!"))
+    IO(expect(sharedString == "hello world!"))
   }
 }
 

--- a/modules/framework/test/src/Global.scala
+++ b/modules/framework/test/src/Global.scala
@@ -1,0 +1,16 @@
+package weaver
+package framework
+
+import cats.effect.IO
+import cats.effect.Resource
+
+object Global extends GlobalResourcesInit {
+  def sharedResources(store: GlobalResources.Write[IO]): Resource[IO, Unit] =
+    for {
+      foo <- Resource.pure[IO, Int](1)
+      _   <- store.putR(foo)
+    } yield ()
+
+  case class Foo[F[_]](fint: F[Int])
+
+}

--- a/modules/framework/test/src/Global.scala
+++ b/modules/framework/test/src/Global.scala
@@ -1,5 +1,6 @@
 package weaver
 package framework
+package test
 
 import cats.effect.IO
 import cats.effect.Resource

--- a/modules/framework/test/src/Meta.scala
+++ b/modules/framework/test/src/Meta.scala
@@ -6,7 +6,6 @@ import cats.effect._
 
 import scala.concurrent.duration.{ TimeUnit, FiniteDuration }
 import java.time.OffsetDateTime
-import java.io.File
 
 // The build tool will only detect and run top-level test suites. We can however nest objects
 // that contain failing tests, to allow for testing the framework without failing the build
@@ -139,29 +138,6 @@ object Meta {
       Some("DogFoodTests.scala"),
       Some("src/main/DogFoodTests.scala"),
       5)
-  }
-
-  object GlobalStub extends GlobalResourcesInit {
-    def sharedResources(store: GlobalResources.Write[IO]): Resource[IO, Unit] =
-      Resource.make(makeTmpFile)(deleteFile).flatMap { file =>
-        store.putR(file)
-      }
-
-    val makeTmpFile                    = IO(java.io.File.createTempFile("hello", ".tmp"))
-    def deleteFile(file: java.io.File) = IO(file.delete()).void
-  }
-
-  class TmpFileSuite(global: GlobalResources) extends IOSuite {
-    type Res = File
-    def sharedResource: Resource[IO, File] =
-      global.in[IO].getOrFailR[File]()
-
-    test("electric boo") { (file, log) =>
-      for {
-        _          <- log.info(s"file:${file.getAbsolutePath()}")
-        fileExists <- IO(file.exists())
-      } yield expect(fileExists) and failure("forcing logs dispatch")
-    }
   }
 
 }

--- a/modules/framework/test/src/Meta.scala
+++ b/modules/framework/test/src/Meta.scala
@@ -3,8 +3,10 @@ package framework
 package test
 
 import cats.effect._
+
 import scala.concurrent.duration.{ TimeUnit, FiniteDuration }
 import java.time.OffsetDateTime
+import java.io.File
 
 // The build tool will only detect and run top-level test suites. We can however nest objects
 // that contain failing tests, to allow for testing the framework without failing the build
@@ -137,6 +139,29 @@ object Meta {
       Some("DogFoodTests.scala"),
       Some("src/main/DogFoodTests.scala"),
       5)
-
   }
+
+  object GlobalStub extends GlobalResourcesInit {
+    def sharedResources(store: GlobalResources.Write[IO]): Resource[IO, Unit] =
+      Resource.make(makeTmpFile)(deleteFile).flatMap { file =>
+        store.putR(file)
+      }
+
+    val makeTmpFile                    = IO(java.io.File.createTempFile("hello", ".tmp"))
+    def deleteFile(file: java.io.File) = IO(file.delete()).void
+  }
+
+  class TmpFileSuite(global: GlobalResources) extends IOSuite {
+    type Res = File
+    def sharedResource: Resource[IO, File] =
+      global.in[IO].getOrFailR[File]()
+
+    test("electric boo") { (file, log) =>
+      for {
+        _          <- log.info(s"file:${file.getAbsolutePath()}")
+        fileExists <- IO(file.exists())
+      } yield expect(fileExists) and failure("forcing logs dispatch")
+    }
+  }
+
 }

--- a/modules/framework/test/src/MutableSuiteTest.scala
+++ b/modules/framework/test/src/MutableSuiteTest.scala
@@ -2,8 +2,6 @@ package weaver
 package framework
 package test
 
-import weaver._
-import cats.implicits._
 import scala.concurrent.duration._
 import java.util.concurrent.TimeUnit
 

--- a/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import scala.concurrent.duration._
 import cats.effect.IO
 
-object PropertyDoFoodTest extends SimpleIOSuite with DogFood {
+object PropertyDogFoodTest extends SimpleIOSuite with DogFood {
 
   test("Failed property tests get reported properly") {
     for {
@@ -28,7 +28,7 @@ object PropertyDoFoodTest extends SimpleIOSuite with DogFood {
       (_, events) <- runSuite(Meta.ParallelChecks)
       _           <- expect(events.size == 1).failFast
     } yield {
-      expect(events.headOption.get.duration() < 5000)
+      expect(events.headOption.get.duration() < 10000)
     }
   }
 

--- a/project/WeaverPlugin.scala
+++ b/project/WeaverPlugin.scala
@@ -1,7 +1,10 @@
 // For getting Scoverage out of the generated POM
 import scala.xml.Elem
 import scala.xml.transform.{ RewriteRule, RuleTransformer }
-import sbtcrossproject.CrossPlugin.autoImport.{ JVMPlatform, crossProjectPlatform }
+import sbtcrossproject.CrossPlugin.autoImport.{
+  JVMPlatform,
+  crossProjectPlatform
+}
 import xerial.sbt.Sonatype.SonatypeKeys._
 
 import sbt._
@@ -99,7 +102,7 @@ object WeaverPlugin extends AutoPlugin {
     "-Ywarn-unused:locals",          // Warn if a local definition is unused.
     "-Ywarn-unused:patvars",         // Warn if a variable bound in a pattern is unused.
     "-Ywarn-unused:privates",        // Warn if a private member is unused.
-    "-Ywarn-value-discard",          // Warn when non-Unit expression results are unused.
+    "-Ywarn-value-discard"           // Warn when non-Unit expression results are unused.
     // "-Xfatal-warnings"               // Fail the compilation if there are any warnings.
   )
 
@@ -150,7 +153,8 @@ object WeaverPlugin extends AutoPlugin {
 
   // Mill-like simple layout
   val simpleLayout: Seq[Setting[_]] = Seq(
-    unmanagedSourceDirectories in Compile := Seq(baseDirectory.value.getParentFile / "src") ++ {
+    unmanagedSourceDirectories in Compile := Seq(
+      baseDirectory.value.getParentFile / "src") ++ {
       if (crossProjectPlatform.value == JVMPlatform)
         Seq(baseDirectory.value.getParentFile / "src-jvm")
       else if (crossProjectPlatform.value == JSPlatform)
@@ -160,7 +164,14 @@ object WeaverPlugin extends AutoPlugin {
     },
     unmanagedSourceDirectories in Test := Seq(
       baseDirectory.value.getParentFile / "test" / "src"
-    )
+    ) ++ {
+      if (crossProjectPlatform.value == JVMPlatform)
+        Seq(baseDirectory.value.getParentFile / "test" / "src-jvm")
+      else if (crossProjectPlatform.value == JSPlatform)
+        Seq(baseDirectory.value.getParentFile / "test" / "src-js")
+      else
+        Seq.empty
+    }
   )
 
   lazy val publishSettings = Seq(

--- a/project/WeaverPlugin.scala
+++ b/project/WeaverPlugin.scala
@@ -100,7 +100,7 @@ object WeaverPlugin extends AutoPlugin {
     "-Ywarn-unused:patvars",         // Warn if a variable bound in a pattern is unused.
     "-Ywarn-unused:privates",        // Warn if a private member is unused.
     "-Ywarn-value-discard",          // Warn when non-Unit expression results are unused.
-    "-Xfatal-warnings"               // Fail the compilation if there are any warnings.
+    // "-Xfatal-warnings"               // Fail the compilation if there are any warnings.
   )
 
   lazy val compilerOptions2_12_Only =

--- a/project/WeaverPlugin.scala
+++ b/project/WeaverPlugin.scala
@@ -102,8 +102,8 @@ object WeaverPlugin extends AutoPlugin {
     "-Ywarn-unused:locals",          // Warn if a local definition is unused.
     "-Ywarn-unused:patvars",         // Warn if a variable bound in a pattern is unused.
     "-Ywarn-unused:privates",        // Warn if a private member is unused.
-    "-Ywarn-value-discard"           // Warn when non-Unit expression results are unused.
-    // "-Xfatal-warnings"               // Fail the compilation if there are any warnings.
+    "-Ywarn-value-discard",          // Warn when non-Unit expression results are unused.
+    "-Xfatal-warnings"               // Fail the compilation if there are any warnings.
   )
 
   lazy val compilerOptions2_12_Only =

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,22 @@
 {
   "docs": {
-    "Overview": ["installation", "motivation"],
-    "Usage": ["common_usage", "expectations", "resources", "logging", "scalacheck", "zio"],
-    "Sample reports": ["multiple_suites_success", "multiple_suites_failures", "multiple_suites_logging"]
+    "Overview": [
+      "installation",
+      "motivation"
+    ],
+    "Usage": [
+      "common_usage",
+      "expectations",
+      "resources",
+      "global_resources",
+      "logging",
+      "scalacheck",
+      "zio"
+    ],
+    "Sample reports": [
+      "multiple_suites_success",
+      "multiple_suites_failures",
+      "multiple_suites_logging"
+    ]
   }
 }


### PR DESCRIPTION
Resolves https://github.com/disneystreaming/weaver-test/issues/7

* When running suites in the context of a build tool, it is currently
impossible to share resources (http clients, databases) between several
suites.

This PR offers a non-intrusive, source-compatible way of doing it.

1. Users can implement `weaver.framework.GlobalResourcesInit` as
custom objects alongside their test suites. This interface is detected
as a task by build tools and managed by our framework implementation.
The method users have to implement provides a "store" (a shared state)
that they can use to store arbitrary objects in a cats.effect.Resource
program. That cats.effect.Resource is used by the framework to allocate
and clean-up resources the users might want to share between tests.
2. What the user can store is expressed in terms of a `ResourceTag`
that needs to be passed implicitly, with a default implementation based
on ClassTags and therefore subject to type-erasure. We try and protect
against type-erasure by preventing the use of this tag for types of kind
`* -> *` or `(* -> *) -> *`.
3. Users can then declare a constructor to their suite
(as opposed to having them be a static object). The constructor must
take a single `weaver.framework.GlobalResources` parameter. This object
offers a read-only interface to the shared store.

Shared resources get cleaned up after all the suites have run.