### PR TITLE
Use scalafix

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -21,3 +21,13 @@ DisableSyntax.noFinalize = true
 DisableSyntax.noValPatterns = false
 DisableSyntax.noUniversalEquality = false
 
+OrganizeImports {
+  coalesceToWildcardImportThreshold = 2147483647 # Int.MaxValue
+  expandRelative = false
+  groupExplicitlyImportedImplicitsSeparately = false
+  groupedImports = Merge
+  groups = ["re:javax?\\.", "scala.", "*"]
+  importSelectorsOrder = Ascii
+  importsOrder = Ascii
+  removeUnused = true
+}

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -7,16 +7,16 @@ rules = [
   ProcedureSyntax
 ]
 
-DisableSyntax.noVars = true
-DisableSyntax.noThrows = true
-DisableSyntax.noNulls = true
+DisableSyntax.noVars = false
+DisableSyntax.noThrows = false
+DisableSyntax.noNulls = false
 DisableSyntax.noReturns = true
 DisableSyntax.noWhileLoops = true
 DisableSyntax.noAsInstanceOf = false
-DisableSyntax.noIsInstanceOf = true
+DisableSyntax.noIsInstanceOf = false
 DisableSyntax.noXml = true
 DisableSyntax.noDefaultArgs = false
-DisableSyntax.noFinalVal = true
+DisableSyntax.noFinalVal = false
 DisableSyntax.noFinalize = true
 DisableSyntax.noValPatterns = false
 DisableSyntax.noUniversalEquality = false

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,23 @@
+rules = [
+  DisableSyntax
+  LeakingImplicitClassVal
+  NoAutoTupling
+  NoValInForComprehension
+  OrganizeImports
+  ProcedureSyntax
+]
+
+DisableSyntax.noVars = true
+DisableSyntax.noThrows = true
+DisableSyntax.noNulls = true
+DisableSyntax.noReturns = true
+DisableSyntax.noWhileLoops = true
+DisableSyntax.noAsInstanceOf = false
+DisableSyntax.noIsInstanceOf = true
+DisableSyntax.noXml = true
+DisableSyntax.noDefaultArgs = false
+DisableSyntax.noFinalVal = true
+DisableSyntax.noFinalize = true
+DisableSyntax.noValPatterns = false
+DisableSyntax.noUniversalEquality = false
+

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -26,7 +26,7 @@ OrganizeImports {
   expandRelative = false
   groupExplicitlyImportedImplicitsSeparately = false
   groupedImports = Merge
-  groups = ["re:javax?\\.", "scala.", "*"]
+  groups = ["re:javax?\\.", "scala.", "cats.", "weaver.", "*"]
   importSelectorsOrder = Ascii
   importsOrder = Ascii
   removeUnused = true

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ addCommandAlias(
 addCommandAlias("release",
                 ";project root ; +publishSigned; sonatypeBundleRelease")
 
-scalaVersion in ThisBuild := WeaverPlugin.scala213
+ThisBuild / scalaVersion := WeaverPlugin.scala213
 
 ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.3.1-RC3"
 
@@ -80,7 +80,7 @@ lazy val framework = crossProject(JSPlatform, JVMPlatform)
       "io.github.cquiroz" %%% "scala-java-time"      % "2.0.0" % Test,
       "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.0.0" % Test
     ),
-    scalacOptions in Test ~= (_ filterNot (_ == "-Xfatal-warnings")),
+    Test / scalacOptions ~= (_ filterNot (_ == "-Xfatal-warnings")),
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
   )
   .jvmSettings(
@@ -136,6 +136,6 @@ lazy val versionDump =
   taskKey[Unit]("Dumps the version in a file named version")
 
 versionDump := {
-  val file = (baseDirectory in ThisBuild).value / "version"
-  IO.write(file, (version in (Compile)).value)
+  val file = (ThisBuild / baseDirectory).value / "version"
+  IO.write(file, (Compile / version).value)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,15 +3,18 @@ import sbtcrossproject.CrossPlugin.autoImport.{ crossProject, CrossType }
 
 addCommandAlias(
   "ci",
-  ";project root ;versionDump; scalafmtCheckAll ;+clean ;+test:compile ;+test; docs/docusaurusCreateSite")
+  ";project root ;versionDump; scalafmtCheckAll; scalafix --check; test:scalafix --check ;+clean ;+test:compile ;+test; docs/docusaurusCreateSite")
 
 addCommandAlias("release",
                 ";project root ; +publishSigned; sonatypeBundleRelease")
 
 scalaVersion in ThisBuild := WeaverPlugin.scala213
 
+ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.3.1-RC3"
+
 lazy val root = project
   .in(file("."))
+  .enablePlugins(ScalafixPlugin)
   .aggregate(coreJVM,
              frameworkJVM,
              scalacheckJVM,

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,37 @@ import sbtcrossproject.CrossPlugin.autoImport.{ crossProject, CrossType }
 
 addCommandAlias(
   "ci",
-  ";project root ;versionDump; scalafmtCheckAll; scalafix --check; test:scalafix --check ;+clean ;+test:compile ;+test; docs/docusaurusCreateSite")
+  Seq(
+    "project root",
+    "versionDump",
+    "scalafmtCheckAll",
+    "scalafix --check",
+    "test:scalafix --check",
+    "+clean",
+    "+test:compile",
+    "+test",
+    "docs/docusaurusCreateSite"
+  ).mkString(";", ";", "")
+)
 
-addCommandAlias("release",
-                ";project root ; +publishSigned; sonatypeBundleRelease")
+addCommandAlias(
+  "fix",
+  Seq(
+    "root/scalafmtAll",
+    "root/scalafmtSbt",
+    "root/scalafix",
+    "root/test:scalafix"
+  ).mkString(";", ";", "")
+)
+
+addCommandAlias(
+  "release",
+  Seq(
+    "project root",
+    "+publishSigned",
+    "sontypeBundleRelease"
+  ).mkString(";", ";", "")
+)
 
 ThisBuild / scalaVersion := WeaverPlugin.scala213
 

--- a/modules/core/src-js/FSCompat.scala
+++ b/modules/core/src-js/FSCompat.scala
@@ -1,6 +1,7 @@
 package weaver
 
 import scala.scalajs.js
+
 import js.annotation._
 
 private[weaver] object FSCompat {

--- a/modules/core/src/weaver/Expect.scala
+++ b/modules/core/src/weaver/Expect.scala
@@ -1,12 +1,11 @@
 package weaver
 
-import com.eed3si9n.expecty._
-
 import cats.data.Validated
-import cats.implicits._
-import cats.data.Validated.Invalid
-import cats.data.Validated.Valid
+import cats.data.Validated.{ Invalid, Valid }
 import cats.effect.Sync
+import cats.implicits._
+
+import com.eed3si9n.expecty._
 
 case class SingleExpectation(run: Validated[String, Unit]) {
   def and(other: Expectations)(implicit loc: SourceLocation) =

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -1,10 +1,9 @@
 package weaver
 
 import cats._
-import cats.implicits._
-import cats.data.{ Validated, ValidatedNel }
 import cats.data.Validated._
-import cats.data.NonEmptyList
+import cats.data.{ NonEmptyList, Validated, ValidatedNel }
+import cats.implicits._
 
 case class Expectations(val run: ValidatedNel[AssertionException, Unit]) {
   self =>

--- a/modules/core/src/weaver/Formatter.scala
+++ b/modules/core/src/weaver/Formatter.scala
@@ -1,9 +1,11 @@
 package weaver
 
-import LogFormatter.{ formatTimestamp }
-import weaver.Log.{ debug, error, info, warn }
 import cats.data.Chain
 import cats.syntax.show._
+
+import weaver.Log.{ debug, error, info, warn }
+
+import LogFormatter.{ formatTimestamp }
 
 object Formatter {
   val EOL        = java.lang.System.lineSeparator()

--- a/modules/core/src/weaver/Log.scala
+++ b/modules/core/src/weaver/Log.scala
@@ -6,6 +6,7 @@ import cats.effect.Timer
 import cats.effect.concurrent.Ref
 import cats.implicits._
 import cats.{ Applicative, FlatMap, Monoid, MonoidK, Show, ~> }
+
 import weaver.Log.PartiallyAppliedLevel
 
 abstract class Log[F[_]] { self =>

--- a/modules/core/src/weaver/Runner.scala
+++ b/modules/core/src/weaver/Runner.scala
@@ -2,9 +2,9 @@ package weaver
 
 import cats.Monoid
 import cats.data.Chain
-import cats.implicits._
 import cats.effect._
 import cats.effect.concurrent.{ MVar, Ref }
+import cats.implicits._
 
 import TestOutcome.{ Summary, Verbose }
 

--- a/modules/core/src/weaver/Test.scala
+++ b/modules/core/src/weaver/Test.scala
@@ -1,12 +1,11 @@
 package weaver
 
-import cats.syntax.all._
+import scala.concurrent.duration.{ MILLISECONDS, _ }
+
 import cats.data.Chain
 import cats.effect.concurrent.Ref
-
-import scala.concurrent.duration.{ MILLISECONDS, _ }
-import cats.effect.Sync
-import cats.effect.Timer
+import cats.effect.{ Sync, Timer }
+import cats.syntax.all._
 
 object Test {
 

--- a/modules/core/src/weaver/TestOutcome.scala
+++ b/modules/core/src/weaver/TestOutcome.scala
@@ -1,8 +1,8 @@
 package weaver
 
-import cats.data.Chain
-
 import scala.concurrent.duration.FiniteDuration
+
+import cats.data.Chain
 
 import TestOutcome.Mode
 

--- a/modules/core/src/weaver/suites.scala
+++ b/modules/core/src/weaver/suites.scala
@@ -1,13 +1,19 @@
 package weaver
 
+import cats.effect.implicits._
+import cats.effect.{
+  ConcurrentEffect,
+  ContextShift,
+  Effect,
+  IO,
+  Resource,
+  Timer
+}
 import cats.syntax.applicative._
 import cats.syntax.applicativeError._
-import cats.effect.{ ContextShift, Effect, IO, Resource, Timer }
-import cats.effect.implicits._
-import fs2.Stream
 
+import fs2.Stream
 import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
-import cats.effect.ConcurrentEffect
 
 // Just a non-parameterized marker trait to help SBT's test detection logic.
 @EnableReflectiveInstantiation

--- a/modules/framework/src-js/DogFoodCompat.scala
+++ b/modules/framework/src-js/DogFoodCompat.scala
@@ -3,6 +3,7 @@ package framework
 
 import cats.effect.IO
 import cats.implicits._
+
 import sbt.testing.{ Task => SbtTask, _ }
 
 private[weaver] object DogFoodCompat {

--- a/modules/framework/src-jvm/DogFoodCompat.scala
+++ b/modules/framework/src-jvm/DogFoodCompat.scala
@@ -3,6 +3,7 @@ package framework
 
 import cats.effect.IO
 import cats.implicits._
+
 import sbt.testing.{ Task => SbtTask, _ }
 
 private[weaver] object DogFoodCompat {

--- a/modules/framework/src/weaver/GlobalResources.scala
+++ b/modules/framework/src/weaver/GlobalResources.scala
@@ -2,13 +2,13 @@ package weaver
 
 import scala.reflect.ClassTag
 import scala.util.Try
+
 import cats.effect._
-import cats.implicits._
-import cats.MonadError
 import cats.effect.concurrent.Ref
+import cats.implicits._
+import cats.{ Applicative, MonadError }
 
 import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
-import cats.Applicative
 
 /**
  * Top-level instances of this trait are detected by the framework and used to manage

--- a/modules/framework/src/weaver/framework/DogFood.scala
+++ b/modules/framework/src/weaver/framework/DogFood.scala
@@ -1,23 +1,25 @@
 package weaver
 package framework
 
-import TestFramework._
-import Fingerprinted._
-
-import cats.syntax.option._
-import cats.data.Chain
-import cats.effect.{ IO, Timer }
-import cats.effect.concurrent.Ref
-import sbt.testing.{
-  Event => SbtEvent,
-  Task => SbtTask,
-  Status => SbtStatus,
-  _
-}
-import Platform._
-import cats.kernel.Eq
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
+
+import cats.data.Chain
+import cats.effect.concurrent.Ref
+import cats.effect.{ IO, Timer }
+import cats.kernel.Eq
+import cats.syntax.option._
+
+import sbt.testing.{
+  Event => SbtEvent,
+  Status => SbtStatus,
+  Task => SbtTask,
+  _
+}
+
+import TestFramework._
+import Fingerprinted._
+import Platform._
 
 // Functionality to test how the frameworks react to successful and failing tests/suites
 trait DogFood {

--- a/modules/framework/src/weaver/framework/ReportTask.scala
+++ b/modules/framework/src/weaver/framework/ReportTask.scala
@@ -1,13 +1,13 @@
 package weaver
 package framework
 
-import weaver.TestOutcome
-
-import cats.effect.IO
 import cats.data.Chain
+import cats.effect.IO
 import cats.implicits._
 
-import sbt.testing.{ TaskDef, Task => BaseTask, Logger => BaseLogger, _ }
+import weaver.TestOutcome
+
+import sbt.testing.{ Logger => BaseLogger, Task => BaseTask, TaskDef, _ }
 
 final class ReportTask(
     processLogs: (Chain[(String, TestOutcome)] => IO[Unit]) => IO[Unit])

--- a/modules/framework/src/weaver/framework/Runner.scala
+++ b/modules/framework/src/weaver/framework/Runner.scala
@@ -1,14 +1,14 @@
 package weaver
 package framework
 
-import TestFramework._
-
-import cats.implicits._
-import cats.effect.{ ContextShift, IO, Timer }
-import cats.effect.concurrent.{ Ref, Semaphore }
 import cats.data.Chain
+import cats.effect.concurrent.{ Ref, Semaphore }
+import cats.effect.{ ContextShift, IO, Resource, Timer }
+import cats.implicits._
+
 import sbt.testing.{ Runner => BaseRunner, Task => BaseTask, _ }
-import cats.effect.Resource
+
+import TestFramework._
 
 final class Runner(
     val args: Array[String],

--- a/modules/framework/src/weaver/framework/Task.scala
+++ b/modules/framework/src/weaver/framework/Task.scala
@@ -1,18 +1,18 @@
 package weaver
 package framework
 
-import cats.effect.IO
-import cats.instances.unit._
-import IO.ioMonoid
-import cats.syntax.foldable._
-import cats.instances.vector._
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
 import cats.data.Chain
+import cats.effect.{ IO, Resource }
+import cats.instances.unit._
+import cats.instances.vector._
+import cats.syntax.foldable._
 
 import sbt.testing.{ Logger => BaseLogger, Task => BaseTask, _ }
 
-import scala.concurrent.duration._
-import scala.util.control.NonFatal
-import cats.effect.Resource
+import IO.ioMonoid
 
 final class Task(
     val task: TaskDef,

--- a/modules/framework/src/weaver/framework/TestFramework.scala
+++ b/modules/framework/src/weaver/framework/TestFramework.scala
@@ -1,8 +1,8 @@
 package weaver.framework
 
+import weaver.{ Platform, discard }
+
 import sbt.testing.{ Framework => BaseFramework, Runner => BaseRunner, _ }
-import weaver.discard
-import weaver.Platform
 
 class TestFramework extends BaseFramework {
 

--- a/modules/framework/src/weaver/framework/WeaverTask.scala
+++ b/modules/framework/src/weaver/framework/WeaverTask.scala
@@ -2,13 +2,13 @@ package weaver
 package framework
 
 import sbt.testing.{
+  Event => SbtEvent,
   Fingerprint,
   OptionalThrowable,
   Selector,
-  TestSelector,
-  Event => SbtEvent,
+  Status => SbtStatus,
   Task => SbtTask,
-  Status => SbtStatus
+  TestSelector
 }
 
 trait WeaverTask extends SbtTask {

--- a/modules/framework/src/weaver/framework/package.scala
+++ b/modules/framework/src/weaver/framework/package.scala
@@ -1,8 +1,10 @@
 package weaver
 
-import cats.effect.IO
-import org.portablescala.reflect.Reflect
 import scala.util.control.NoStackTrace
+
+import cats.effect.IO
+
+import org.portablescala.reflect.Reflect
 
 package object framework {
 

--- a/modules/framework/test/src-jvm/MetaJVM.scala
+++ b/modules/framework/test/src-jvm/MetaJVM.scala
@@ -2,9 +2,9 @@ package weaver
 package framework
 package test
 
-import cats.effect._
-
 import java.io.File
+
+import cats.effect._
 
 // The build tool will only detect and run top-level test suites. We can however nest objects
 // that contain failing tests, to allow for testing the framework without failing the build

--- a/modules/framework/test/src/DogFoodTests.scala
+++ b/modules/framework/test/src/DogFoodTests.scala
@@ -2,9 +2,10 @@ package weaver
 package framework
 package test
 
-import cats.implicits._
-import sbt.testing.Status
 import cats.data.Chain
+import cats.implicits._
+
+import sbt.testing.Status
 
 object DogFoodSuite extends SimpleIOSuite with DogFood {
   simpleTest("test suite reports successes events") {

--- a/modules/framework/test/src/Global.scala
+++ b/modules/framework/test/src/Global.scala
@@ -2,8 +2,7 @@ package weaver
 package framework
 package test
 
-import cats.effect.IO
-import cats.effect.Resource
+import cats.effect.{ IO, Resource }
 
 object SharedResources extends GlobalResourcesInit {
   def sharedResources(store: GlobalResources.Write[IO]): Resource[IO, Unit] =

--- a/modules/framework/test/src/Meta.scala
+++ b/modules/framework/test/src/Meta.scala
@@ -2,10 +2,11 @@ package weaver
 package framework
 package test
 
-import cats.effect._
-
-import scala.concurrent.duration.{ TimeUnit, FiniteDuration }
 import java.time.OffsetDateTime
+
+import scala.concurrent.duration.{ FiniteDuration, TimeUnit }
+
+import cats.effect._
 
 // The build tool will only detect and run top-level test suites. We can however nest objects
 // that contain failing tests, to allow for testing the framework without failing the build

--- a/modules/framework/test/src/MutableSuiteTest.scala
+++ b/modules/framework/test/src/MutableSuiteTest.scala
@@ -2,8 +2,9 @@ package weaver
 package framework
 package test
 
-import scala.concurrent.duration._
 import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration._
 
 abstract class MutableSuiteTest extends SimpleIOSuite {
 

--- a/modules/framework/test/src/TestConsole.scala
+++ b/modules/framework/test/src/TestConsole.scala
@@ -3,7 +3,7 @@ package framework
 package test
 
 object TestConsole {
-  private val ansiColorRgx = """\u001b\[([;\d]*)m""".r
+  private val ansiColorRgx = "\u001b\\[([;\\d]*)m".r
 
   def removeASCIIColors(str: String) =
     ansiColorRgx.replaceAllIn(str, "")

--- a/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
@@ -1,14 +1,13 @@
 package weaver
 package scalacheck
 
+import cats.Show
+import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.implicits._
 
-import org.scalacheck.Gen
-import cats.effect.IO
 import org.scalacheck.rng.Seed
-import cats.Show
-import org.scalacheck.Arbitrary
-import cats.effect.concurrent.Ref
+import org.scalacheck.{ Arbitrary, Gen }
 
 trait IOCheckers extends Checkers[IO] {
   self: ConcurrentEffectSuite[IO] =>

--- a/modules/scalacheck/test/src/weaver/scalacheck/CheckersTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/CheckersTest.scala
@@ -1,10 +1,12 @@
 package weaver
 package scalacheck
 
-import org.scalacheck.Gen
 import scala.concurrent.duration._
-import cats.implicits._
+
 import cats.effect.IO
+import cats.implicits._
+
+import org.scalacheck.Gen
 
 object CheckersTest extends SimpleIOSuite with IOCheckers {
 

--- a/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -1,10 +1,12 @@
 package weaver
 package scalacheck
 
-import weaver.framework._
-import cats.implicits._
 import scala.concurrent.duration._
+
 import cats.effect.IO
+import cats.implicits._
+
+import weaver.framework._
 
 object PropertyDogFoodTest extends SimpleIOSuite with DogFood {
 

--- a/modules/zio/src/weaver/ziocompat/RefLog.scala
+++ b/modules/zio/src/weaver/ziocompat/RefLog.scala
@@ -1,10 +1,10 @@
 package weaver.ziocompat
 
+import cats.data.Chain
+
 import weaver.Log
 
 import zio._
-
-import cats.data.Chain
 
 class RefLog(ref: Ref[Chain[Log.Entry]]) extends Log[UIO] { self =>
   def log(l: => Log.Entry): UIO[Unit] =

--- a/modules/zio/src/weaver/ziocompat/Test.scala
+++ b/modules/zio/src/weaver/ziocompat/Test.scala
@@ -2,12 +2,14 @@ package weaver.ziocompat
 
 import java.util.concurrent.TimeUnit
 
-import cats.data.Chain
-import weaver.{ Expectations, Log, Result, TestOutcome }
-import zio._
-
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
+
+import cats.data.Chain
+
+import weaver.{ Expectations, Log, Result, TestOutcome }
+
+import zio._
 
 object Test {
 

--- a/modules/zio/src/weaver/ziocompat/log.scala
+++ b/modules/zio/src/weaver/ziocompat/log.scala
@@ -2,8 +2,8 @@ package weaver
 package ziocompat
 
 import zio._
-import zio.interop.catz.implicits._
 import zio.interop.catz.core._
+import zio.interop.catz.implicits._
 
 object log {
 

--- a/modules/zio/src/weaver/ziocompat/suites.scala
+++ b/modules/zio/src/weaver/ziocompat/suites.scala
@@ -1,12 +1,13 @@
 package weaver
 package ziocompat
 
+import scala.util.Try
+
 import cats.effect.ConcurrentEffect
+
 import fs2._
 import zio._
 import zio.interop.catz._
-
-import scala.util.Try
 
 abstract class MutableZIOSuite[Res <: Has[_]](implicit tag: Tag[Res])
     extends ConcurrentEffectSuite[Task] {

--- a/modules/zio/test/src/weaver/ziocompat/MutableZIOSuiteTest.scala
+++ b/modules/zio/test/src/weaver/ziocompat/MutableZIOSuiteTest.scala
@@ -1,8 +1,9 @@
 package weaver.ziocompat
 
-import sbt.testing.Status
 import weaver.framework.DogFood
 import weaver.ziocompat.modules._
+
+import sbt.testing.Status
 import zio._
 import zio.duration._
 

--- a/project/WeaverPlugin.scala
+++ b/project/WeaverPlugin.scala
@@ -5,6 +5,7 @@ import sbtcrossproject.CrossPlugin.autoImport.{
   JVMPlatform,
   crossProjectPlatform
 }
+import scalafix.sbt.ScalafixPlugin.autoImport._
 import xerial.sbt.Sonatype.SonatypeKeys._
 
 import sbt._
@@ -51,7 +52,10 @@ object WeaverPlugin extends AutoPlugin {
     ),
     // https://github.com/sbt/sbt/issues/2654
     incOptions := incOptions.value.withLogRecompileOnMacro(false),
-    testFrameworks := Seq(new TestFramework("weaver.framework.TestFramework"))
+    testFrameworks := Seq(new TestFramework("weaver.framework.TestFramework")),
+    // https://scalacenter.github.io/scalafix/docs/users/installation.html
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision
   ) ++ coverageSettings ++ publishSettings
 
   def compilerOptions(scalaVersion: String) = {

--- a/project/WeaverPlugin.scala
+++ b/project/WeaverPlugin.scala
@@ -38,10 +38,10 @@ object WeaverPlugin extends AutoPlugin {
     crossScalaVersions := supportedScalaVersions,
     scalacOptions ++= compilerOptions(scalaVersion.value),
     // Turning off fatal warnings for ScalaDoc, otherwise we can't release.
-    scalacOptions in (Compile, doc) ~= (_ filterNot (_ == "-Xfatal-warnings")),
+    Compile / doc / scalacOptions ~= (_ filterNot (_ == "-Xfatal-warnings")),
     // ScalaDoc settings
     autoAPIMappings := true,
-    scalacOptions in ThisBuild ++= Seq(
+    ThisBuild / scalacOptions ++= Seq(
       // Note, this is used by the doc-source-url feature to determine the
       // relative path of a given source file. If it's not a prefix of a the
       // absolute path of the source file, the absolute path of that file
@@ -142,9 +142,9 @@ object WeaverPlugin extends AutoPlugin {
 
   lazy val doNotPublishArtifact = Seq(
     publishArtifact := false,
-    publishArtifact in (Compile, packageDoc) := false,
-    publishArtifact in (Compile, packageSrc) := false,
-    publishArtifact in (Compile, packageBin) := false
+    Compile / packageDoc / publishArtifact := false,
+    Compile / packageSrc / publishArtifact := false,
+    Compile / packageBin / publishArtifact := false
   )
 
   def profile: Project => Project = pr => {
@@ -157,7 +157,7 @@ object WeaverPlugin extends AutoPlugin {
 
   // Mill-like simple layout
   val simpleLayout: Seq[Setting[_]] = Seq(
-    unmanagedSourceDirectories in Compile := Seq(
+    Compile / unmanagedSourceDirectories := Seq(
       baseDirectory.value.getParentFile / "src") ++ {
       if (crossProjectPlatform.value == JVMPlatform)
         Seq(baseDirectory.value.getParentFile / "src-jvm")
@@ -166,7 +166,7 @@ object WeaverPlugin extends AutoPlugin {
       else
         Seq.empty
     },
-    unmanagedSourceDirectories in Test := Seq(
+    Test / unmanagedSourceDirectories := Seq(
       baseDirectory.value.getParentFile / "test" / "src"
     ) ++ {
       if (crossProjectPlatform.value == JVMPlatform)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,7 @@
 val ScalaJSVersion =
   Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.1.1")
 
+addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.9.17")
 addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % ScalaJSVersion)
 addSbtPlugin("org.portable-scala"   % "sbt-scalajs-crossproject"      % "1.0.0")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"                       % "2.0.1")


### PR DESCRIPTION
Hi folks,

What this does:

## Interesting

* Enables [scalafix](https://scalacenter.github.io/scalafix/)
* Organise imports using [scalafix-organize-imports](https://github.com/liancheng/scalafix-organize-imports)
* Add a sbt `fix` alias to run scalafix and scalafmt
* Run `fix` over the project and commit the results

## Refactoring

* In SBT files prefer the syntax `<scope> / <scope>` over `<scope> in <scope>`
* Alias task list are now constructed from a `Seq` - makes it easier to scan