### PR TITLE
Add an interop module for specs2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,6 +12,7 @@ steps:
   environment:
     COURSIER_CACHE: .cache/coursier
     JAVA_OPTS: "-XX:MaxMetaspaceSize=1g -Xms1g -Xmx2g -Xss2M"
+    SBT_OPTS: "-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=2g -Xmx2g"
   volumes:
     - name: sbt-cache
       path: /root/.sbt

--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ brew install git-lfs
 git lfs install
 ```
 
+If you want to build and run the website then you will need yarn installed:
+
+```bash
+brew install yarn
+```
+
+### PR Guidelines
+
+Please:
+- Sign the CLA
+- Write positive and negative tests
+- Include documentation
+
 ## Inspiration
 
 A **HUGE** thank you to Alexandru Nedelcu, author of [Monix](https://github.com/monix/monix) and contributor to

--- a/build.sbt
+++ b/build.sbt
@@ -46,10 +46,12 @@ lazy val root = project
              frameworkJVM,
              scalacheckJVM,
              zioJVM,
+             specs2JVM,
              coreJS,
              frameworkJS,
              scalacheckJS,
-             zioJS)
+             zioJS,
+             specs2JS)
   .configure(WeaverPlugin.profile)
   .settings(WeaverPlugin.doNotPublishArtifact)
   .settings(
@@ -73,6 +75,11 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .jvmSettings(
     libraryDependencies ++= Seq(
       "org.scala-js" %%% "scalajs-stubs" % "1.0.0" % "provided"
+    )
+  )
+  .jsSettings(
+    libraryDependencies ++= Seq(
+      "io.github.cquiroz" %%% "scala-java-time" % "2.0.0"
     )
   )
 
@@ -133,14 +140,30 @@ lazy val scalacheck = crossProject(JSPlatform, JVMPlatform)
   .settings(WeaverPlugin.simpleLayout)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scalacheck"    %%% "scalacheck"      % "1.14.3",
-      "io.github.cquiroz" %%% "scala-java-time" % "2.0.0" % Test
+      "org.scalacheck" %%% "scalacheck" % "1.14.3"
     ),
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
   )
 
 lazy val scalacheckJVM = scalacheck.jvm
 lazy val scalacheckJS  = scalacheck.js
+
+lazy val specs2 = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("modules/specs2"))
+  .dependsOn(core, framework % "test->compile")
+  .configure(WeaverPlugin.profile)
+  .settings(
+    name := "specs2",
+    libraryDependencies ++= Seq(
+      "org.specs2" %%% "specs2-matcher" % "4.10.0"
+    ),
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+  .settings(WeaverPlugin.simpleLayout)
+
+lazy val specs2JVM = specs2.jvm
+lazy val specs2JS  = specs2.js
 
 lazy val zio = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)

--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val coreJS  = core.js
 lazy val docs = project
   .in(file("modules/docs"))
   .enablePlugins(DocusaurusPlugin, MdocPlugin)
-  .dependsOn(coreJVM, frameworkJVM, scalacheckJVM, zioJVM)
+  .dependsOn(coreJVM, frameworkJVM, scalacheckJVM, zioJVM, specs2JVM)
   .settings(
     moduleName := "docs",
     watchSources += (ThisBuild / baseDirectory).value / "docs",

--- a/docs/specs2.md
+++ b/docs/specs2.md
@@ -1,0 +1,69 @@
+---
+id: specs2
+title: specs2 integration
+---
+
+Weaver comes with [specs2](http://specs2.org/) matchers interop, allowing for matcher style testing.
+
+## Installation
+
+You'll need to install an additional dependency in order to use specs2 matchers with Weaver.
+
+### SBT
+```scala
+libraryDependencies +=  "com.disneystreaming" %% "weaver-specs2" % "@VERSION@" % Test
+```
+
+### Mill
+```scala
+object test extends Tests {
+  def ivyDeps = Agg(
+    ivy"com.disneystreaming::weaver-specs2:@VERSION@"
+  )
+}
+```
+
+## Usage
+
+Add the `weaver.specs2compat.IOMatchers` mixin to use specs2 matchers within your test suite.
+
+```scala mdoc
+import weaver.SimpleIOSuite
+
+import weaver.specs2compat.IOMatchers
+
+object MatchersSpec extends SimpleIOSuite with IOMatchers {
+  pureTest("pureTest { 1 must beEqualTo(1) }") {
+    1 must beEqualTo(1)
+  }
+
+  pureTest("pureTest { 1 must be_==(1) }") {
+    1 must be_==(1)
+  }
+
+  pureTest("pureTest { 1 mustEqual 1 }") {
+    1 mustEqual 1
+  }
+
+  pureTest("pureTest { 1 === 1 }") {
+    1 === 1
+  }
+
+  simpleTest("simpleTest { 1 must beEqualTo(1) }") {
+    1 must beEqualTo(1)
+  }
+
+  simpleTest("simpleTest { 1 must be_==(1) }") {
+    1 must be_==(1)
+  }
+
+  simpleTest("simpleTest { 1 mustEqual 1 }") {
+    1 mustEqual 1
+  }
+
+  simpleTest("simpleTest { 1 === 1 }") {
+    1 === 1
+  }
+}
+
+```

--- a/modules/specs2/src/weaver/specs2compat/Matchers.scala
+++ b/modules/specs2/src/weaver/specs2compat/Matchers.scala
@@ -1,0 +1,39 @@
+package weaver.specs2compat
+
+import cats.Monoid
+import cats.data.Validated
+import cats.effect.IO
+
+import weaver.{ AssertionException, EffectSuite, Expectations, SourceLocation }
+
+import org.specs2.matcher.{ MatchResult, MustMatchers }
+
+trait Matchers[F[_]] extends MustMatchers {
+  self: EffectSuite[F] =>
+
+  implicit def toExpectations[A](
+      m: MatchResult[A]
+  )(
+      implicit pos: SourceLocation
+  ): Expectations =
+    if (m.toResult.isSuccess) {
+      Monoid[Expectations].empty
+    } else {
+      Expectations(Validated.invalidNel(new AssertionException(
+        m.toResult.message,
+        pos)))
+    }
+
+  implicit def toExpectationsF[A](
+      m: MatchResult[A]
+  )(
+      implicit pos: SourceLocation
+  ): F[Expectations] = effect.pure {
+    toExpectations(m)
+  }
+
+}
+
+trait IOMatchers extends Matchers[IO] {
+  self: EffectSuite[IO] =>
+}

--- a/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
+++ b/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
@@ -1,0 +1,73 @@
+package weaver.specs2compat
+
+import weaver.{ Expectations, SimpleIOSuite }
+
+import org.specs2.matcher.MatchResult
+
+object MatchersSpec extends SimpleIOSuite with IOMatchers {
+  pureTest("pureTest { 1 must beEqualTo(1) }") {
+    1 must beEqualTo(1)
+  }
+
+  pureTest("pureTest { 1 must be_==(1) }") {
+    1 must be_==(1)
+  }
+
+  pureTest("pureTest { 1 must_== 1 }") {
+    1 must_== 1
+  }
+
+  pureTest("pureTest { 1 mustEqual 1 }") {
+    1 mustEqual 1
+  }
+
+  pureTest("pureTest { 1 === 1 }") {
+    1 === 1
+  }
+
+  def expectFailure[A](matchResult: MatchResult[A]): Expectations = {
+    matchResult.run.toEither.fold(
+      nel => expect(nel.head.message == matchResult.toResult.message),
+      _ => failure("Expected assertion exception")
+    )
+  }
+
+  pureTest("simpleTest { expectFailure { 1 must beEqualTo(2) } }") {
+    expectFailure { 1 must beEqualTo(2) }
+  }
+
+  pureTest("simpleTest { expectFailure { 1 must be_==(2) } }") {
+    expectFailure(1 must be_==(2))
+  }
+
+  pureTest("simpleTest { expectFailure { 1 must_== 2 } }") {
+    expectFailure(1 must_== 2)
+  }
+
+  pureTest("simpleTest { expectFailure { 1 mustEqual 2 } }") {
+    expectFailure { 1 mustEqual 2 }
+  }
+
+  pureTest("simpleTest { expectFailure { 1 === 2 failed } }") {
+    expectFailure(1 === 2)
+  }
+  simpleTest("simpleTest { 1 must beEqualTo(1) }") {
+    1 must beEqualTo(1)
+  }
+
+  simpleTest("simpleTest { 1 must be_==(1) }") {
+    1 must be_==(1)
+  }
+
+  simpleTest("simpleTest { 1 must_== 1 }") {
+    1 must_== 1
+  }
+
+  simpleTest("simpleTest { 1 mustEqual 1 }") {
+    1 mustEqual 1
+  }
+
+  simpleTest("simpleTest { 1 === 1 }") {
+    1 === 1
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,3 @@ addSbtPlugin("org.scalameta"        % "sbt-scalafmt"                  % "2.3.0")
 addSbtPlugin("org.scalameta"        % "sbt-scalafmt"                  % "2.4.2")
 addSbtPlugin("org.scoverage"        % "sbt-scoverage"                 % "1.6.1")
 addSbtPlugin("org.scalameta"        % "sbt-mdoc"                      % "2.2.5")
-

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -11,7 +11,8 @@
       "global_resources",
       "logging",
       "scalacheck",
-      "zio"
+      "zio",
+      "specs2"
     ],
     "Sample reports": [
       "multiple_suites_success",


### PR DESCRIPTION
So that people can more easily migrate from specs2 whilst still
leveraging the matchers provided by that framework.

**TODO**

- [x] Fix up JS project
- [x] Rename packages
- [x] Remove accidental inclusion of bloop plugin
- [x] Add documentation
- [x] Investigate build OOM issue