### PR TITLE
Avoid spawning new testing tasks

### DIFF
--- a/modules/framework/src/weaver/framework/ReportTask.scala
+++ b/modules/framework/src/weaver/framework/ReportTask.scala
@@ -5,48 +5,7 @@ import cats.data.Chain
 import cats.effect.IO
 import cats.implicits._
 
-import weaver.TestOutcome
-
-import sbt.testing.{ Logger => BaseLogger, Task => BaseTask, TaskDef, _ }
-
-final class ReportTask(
-    processLogs: (Chain[(String, TestOutcome)] => IO[Unit]) => IO[Unit])
-    extends WeaverTask { self =>
-
-  def tags(): Array[String] = Array.empty
-
-  def execute(
-      eventHandler: EventHandler,
-      loggers: Array[BaseLogger],
-      continuation: Array[BaseTask] => Unit): Unit = {
-    executeWrapper(eventHandler, loggers)
-      .map(continuation)
-      .unsafeRunAsyncAndForget()
-  }
-
-  def execute(
-      eventHandler: EventHandler,
-      loggers: Array[BaseLogger]): Array[BaseTask] = {
-    executeWrapper(eventHandler, loggers).unsafeRunSync()
-  }
-
-  override def taskDef(): TaskDef = {
-    new TaskDef("weaver.framework.ReportTask",
-                new Fingerprint {},
-                false,
-                Array())
-  }
-
-  private def executeWrapper(
-      eventHandler: EventHandler,
-      loggers: Array[BaseLogger]): IO[Array[BaseTask]] = {
-    discard[EventHandler](eventHandler)
-    processLogs(ReportTask.report(loggers)).attempt.map {
-      case Right(_) => Array.empty[BaseTask]
-      case Left(e)  => e.printStackTrace(); Array.empty[BaseTask]
-    }
-  }
-}
+import sbt.testing.{ Logger => BaseLogger }
 
 object ReportTask {
 

--- a/modules/framework/src/weaver/framework/Runner.scala
+++ b/modules/framework/src/weaver/framework/Runner.scala
@@ -7,9 +7,9 @@ import cats.effect.{ ContextShift, IO, Resource, Timer }
 import cats.implicits._
 
 import sbt.testing.{
+  Logger => BaseLogger,
   Runner => BaseRunner,
   Task => BaseTask,
-  Logger => BaseLogger,
   _
 }
 


### PR DESCRIPTION
Spawning new testing tasks is not needed : we are abusing sbt's test
interface on JVM to gather up test results, and the reporting logic can be
inlined within the last running task without issue.

Spwaning new testing tasks has an undesirable side effect when using the
framework in bloop : bloop reports partial results for each task, and
spawning new testing tasks that do not actually do any testing lead to a
lot of noise.