### PR TITLE
Update fs2-core to 2.4.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .settings(WeaverPlugin.simpleLayout)
   .settings(
     libraryDependencies ++= Seq(
-      "co.fs2"               %%% "fs2-core"               % "2.4.2",
+      "co.fs2"               %%% "fs2-core"               % "2.4.3",
       "org.typelevel"        %%% "cats-effect"            % "2.1.4",
       "com.eed3si9n.expecty" %%% "expecty"                % "0.13.0",
       "org.portable-scala"   %%% "portable-scala-reflect" % "1.0.0"

--- a/modules/core/src/weaver/Runner.scala
+++ b/modules/core/src/weaver/Runner.scala
@@ -3,7 +3,7 @@ package weaver
 import cats.Monoid
 import cats.data.Chain
 import cats.effect._
-import cats.effect.concurrent.{ MVar, Ref }
+import cats.effect.concurrent.{ MVar, MVar2, Ref }
 import cats.implicits._
 
 import TestOutcome.{ Summary, Verbose }
@@ -14,7 +14,7 @@ class Runner[F[_]: Concurrent](args: List[String], maxConcurrentSuites: Int)(
   import Runner._
 
   // Signaling option, because we need to detect completion
-  type Channel[A] = MVar[F, Option[A]]
+  type Channel[A] = MVar2[F, Option[A]]
 
   def run(suites: fs2.Stream[F, Suite[F]]): F[Outcome] =
     for {


### PR DESCRIPTION
Supersedes the Scala Steward PR: https://github.com/disneystreaming/weaver-test/pull/55

- Upgrades the `fs2-core` dependency to 2.4.3
- Fixes compilation, avoids using deprecated code from the upgrade