### PR TITLE
Decouple EffectSuite from Expecations.Helpers

### DIFF
--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -83,6 +83,12 @@ object Expectations {
 
   trait Helpers {
 
+    /**
+     * Expect macros
+     */
+    def expect = new Expect
+    def assert = new Expect
+
     val success: Expectations = Monoid[Expectations].empty
 
     def failure(hint: String)(implicit pos: SourceLocation): Expectations =

--- a/modules/core/src/weaver/suites.scala
+++ b/modules/core/src/weaver/suites.scala
@@ -25,7 +25,7 @@ trait Suite[F[_]] extends BaseSuiteClass {
 }
 
 // format: off
-trait EffectSuite[F[_]] extends Suite[F] with Expectations.Helpers { self =>
+trait EffectSuite[F[_]] extends Suite[F]{ self =>
 
   implicit def effect : Effect[F]
 
@@ -40,12 +40,6 @@ trait EffectSuite[F[_]] extends Suite[F] with Expectations.Helpers { self =>
    */
   def ignore(reason: String)(implicit pos: SourceLocation): F[Nothing] =
     effect.raiseError(new IgnoredException(Some(reason), pos))
-
-  /**
-   * Expect macro
-   */
-  def expect = new Expect
-  def assert = new Expect
 
   override def name : String = self.getClass.getName.replace("$", "")
 
@@ -72,7 +66,7 @@ trait BaseIOSuite { self : ConcurrentEffectSuite[IO] =>
   implicit def effect : ConcurrentEffect[IO] = IO.ioConcurrentEffect
 }
 
-trait PureIOSuite extends ConcurrentEffectSuite[IO] with BaseIOSuite {
+trait PureIOSuite extends ConcurrentEffectSuite[IO] with BaseIOSuite with Expectations.Helpers {
 
   def pureTest(name: String)(run : => Expectations) : IO[TestOutcome] = Test[IO](name, IO(run))
   def simpleTest(name:  String)(run : IO[Expectations]) : IO[TestOutcome] = Test[IO](name, run)
@@ -131,9 +125,9 @@ trait MutableFSuite[F[_]] extends ConcurrentEffectSuite[F]  {
 
 }
 
-trait MutableIOSuite extends MutableFSuite[IO] with BaseIOSuite
+trait MutableIOSuite extends MutableFSuite[IO] with BaseIOSuite with Expectations.Helpers
 
-trait SimpleMutableIOSuite extends MutableIOSuite{
+trait SimpleMutableIOSuite extends MutableIOSuite {
   type Res = Unit
   def sharedResource: Resource[IO, Unit] = Resource.pure(())
 }

--- a/modules/monix/src/weaver/monixcompat/suites.scala
+++ b/modules/monix/src/weaver/monixcompat/suites.scala
@@ -15,7 +15,10 @@ trait BaseTaskSuite { self: ConcurrentEffectSuite[Task] =>
     new CatsConcurrentEffectForTask()(scheduler, Task.defaultOptions)
 }
 
-trait MutableTaskSuite extends MutableFSuite[Task] with BaseTaskSuite
+trait MutableTaskSuite
+    extends MutableFSuite[Task]
+    with BaseTaskSuite
+    with Expectations.Helpers
 
 trait SimpleMutableTaskSuite extends MutableTaskSuite {
   type Res = Unit

--- a/modules/zio/src/weaver/ziocompat/suites.scala
+++ b/modules/zio/src/weaver/ziocompat/suites.scala
@@ -9,7 +9,7 @@ import fs2._
 import zio._
 import zio.interop.catz._
 
-abstract class MutableZIOSuite[Res <: Has[_]](implicit tag: Tag[Res])
+abstract class BaseMutableZIOSuite[Res <: Has[_]](implicit tag: Tag[Res])
     extends ConcurrentEffectSuite[Task] {
 
   val sharedLayer: ZLayer[ZEnv, Throwable, Res]
@@ -69,7 +69,11 @@ abstract class MutableZIOSuite[Res <: Has[_]](implicit tag: Tag[Res])
   }
 }
 
-trait SimpleMutableZIOSuite extends MutableZIOSuite[Has[Unit]] {
+abstract class MutableZIOSuite[Res <: Has[_]](implicit tag: Tag[Res])
+    extends BaseMutableZIOSuite()(tag)
+    with Expectations.Helpers
+
+abstract class SimpleMutableZIOSuite extends MutableZIOSuite[Has[Unit]] {
   override val sharedLayer: zio.ZLayer[ZEnv, Throwable, Has[Unit]] =
     ZLayer.fromEffect(UIO.unit)
 }


### PR DESCRIPTION
Makes it possible to tap into some suite abstract classes / traits
without buying into the default ways of constructing expectations.

This change should retain compatibility in most cases for end users.