### PR TITLE
WIP: GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,12 @@
-name: Build and Test
+name: Publish documentation
 
 on:
   push:
-    branches:
-      - master
-  pull_request:
+    tags:
+      - v*
 
 jobs:
-  test:
+  publish:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
@@ -18,8 +17,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Run tests
-      run: sbt ci
+    - name: Set up Node.js and Yarn
+      uses: actions/setup-node@v2-beta
+      with:
+        node-version: 12
+    - name: Publish docs
+      run: sbt docs/docusaurusPublishGhpages
       env:
-        JAVA_OPTS: "-XX:MaxMetaspaceSize=1g -Xms1g -Xmx2g -Xss2M"
-        SBT_OPTS: "-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=2g -Xmx2g"
+        GITHUB_DEPLOY_KEY: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish documentation
 
 on:
   push:
+    pull_request:
     tags:
       - v*
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - v*
-  pull_request
+  pull_request:
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,9 @@ name: Publish documentation
 
 on:
   push:
-    pull_request:
     tags:
       - v*
+  pull_request
 
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    run-on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish documentation
+name: Release artifact
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    run-on: ubuntu-latest
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
@@ -19,11 +19,8 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Set up Node.js and Yarn
-      uses: actions/setup-node@v2-beta
-      with:
-        node-version: 12
-    - name: Publish docs
-      run: sbt docs/docusaurusPublishGhpages
+    - name: Release artifact
+      run: sbt release
       env:
-        GITHUB_DEPLOY_KEY: ${{ secrets.GITHUB_DEPLOY_KEY }}
+        - SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+        - SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         JAVA_OPTS: "-XX:MaxMetaspaceSize=1g -Xms1g -Xmx2g -Xss2M"
         SBT_OPTS: "-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=2g -Xmx2g"
     - name: Set up Node.js and Yarn
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v2-beta
       with:
         node-version: 12
     - name: Publish docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,23 +1,21 @@
-name: Build and Test
-
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-
+name: Test
+on: push
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  job:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        javaVersion: [1.8, 1.11]
+    runs-on: ${{matrix.os}}
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
     - name: Restore Coursier cache
       uses: coursier/cache-action@v3
-    - name: Set up JDK 1.8
+    - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: ${{matrix.javaVersion}}
     - name: Run tests
       run: sbt ci
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
-    - name: Set up Coursier cache
+    - name: Restore Coursier cache
       uses: coursier/cache-action@v3
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,3 +20,6 @@ jobs:
         java-version: 1.8
     - name: Run tests
       run: sbt ci
+      env:
+        JAVA_OPTS: "-XX:MaxMetaspaceSize=1g -Xms1g -Xmx2g -Xss2M"
+        SBT_OPTS: "-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=2g -Xmx2g"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,7 @@ jobs:
       env:
         JAVA_OPTS: "-XX:MaxMetaspaceSize=1g -Xms1g -Xmx2g -Xss2M"
         SBT_OPTS: "-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=2g -Xmx2g"
+    - name: Publish docs
+      run: sbt docs/docusaurusPublishGhpages
+      env:
+        GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
+    - name: Set up Coursier cache
+      uses: coursier/cache-action@v3
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Run tests
+      run: sbt ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,8 @@ jobs:
   job:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
         javaVersion: [1.8, 1.11]
-    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,10 @@ jobs:
       env:
         JAVA_OPTS: "-XX:MaxMetaspaceSize=1g -Xms1g -Xmx2g -Xss2M"
         SBT_OPTS: "-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=2g -Xmx2g"
+    - name: Set up Node.js and Yarn
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12
     - name: Publish docs
       run: sbt docs/docusaurusPublishGhpages
       env:


### PR DESCRIPTION
Current strategy is to have three workflow files (test, website publish and artifact release), so that they may react to events differently. This means the Coursier and SBT cache isn't shared, and there is a little duplication of code. 

It may be possible to consolidate all the files into a single workflow [using `if` workflow syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif). 

I've verified that the test workflow works on my fork, https://github.com/bfdes/weaver-test/pull/1, but the other two require secrets to be present. This might still be possible on my end. 