### PR TITLE
Expecty 0.14.1 / expectations rework

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ steps:
   - echo Built $(cat version)
   environment:
     COURSIER_CACHE: .cache/coursier
-    JAVA_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
+    SBT_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
   volumes:
     - name: sbt-cache
       path: /root/.sbt
@@ -27,7 +27,7 @@ steps:
   - sbt release
   environment:
     COURSIER_CACHE: .cache/coursier
-    JAVA_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
+    SBT_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
     SONATYPE_USER:
       from_secret: sonatype_username
     SONATYPE_PASSWORD:
@@ -51,7 +51,7 @@ steps:
   - amm scripts/releasePlugin.sc $(cat intellijPlugin)
   environment:
     COURSIER_CACHE: .cache/coursier
-    JAVA_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
+    SBT_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
     GITHUB_TOKEN:
       from_secret: github_api_token
   when:
@@ -72,7 +72,7 @@ steps:
   - echo done publishing website
   environment:
     COURSIER_CACHE: .cache/coursier
-    JAVA_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
+    SBT_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
     GIT_USER: $DRONE_COMMIT_AUTHOR
     GITHUB_DEPLOY_KEY:
       from_secret: github_deploy_key

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ steps:
   - echo Built $(cat version)
   environment:
     COURSIER_CACHE: .cache/coursier
-    JAVA_OPTS: "-XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
+    JAVA_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
   volumes:
     - name: sbt-cache
       path: /root/.sbt
@@ -27,6 +27,7 @@ steps:
   - sbt release
   environment:
     COURSIER_CACHE: .cache/coursier
+    JAVA_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
     SONATYPE_USER:
       from_secret: sonatype_username
     SONATYPE_PASSWORD:
@@ -50,6 +51,7 @@ steps:
   - amm scripts/releasePlugin.sc $(cat intellijPlugin)
   environment:
     COURSIER_CACHE: .cache/coursier
+    JAVA_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
     GITHUB_TOKEN:
       from_secret: github_api_token
   when:
@@ -70,6 +72,7 @@ steps:
   - echo done publishing website
   environment:
     COURSIER_CACHE: .cache/coursier
+    JAVA_OPTS: "-XX:+UseG1GC -XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
     GIT_USER: $DRONE_COMMIT_AUTHOR
     GITHUB_DEPLOY_KEY:
       from_secret: github_deploy_key

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,8 +11,7 @@ steps:
   - echo Built $(cat version)
   environment:
     COURSIER_CACHE: .cache/coursier
-    JAVA_OPTS: "-XX:MaxMetaspaceSize=1g -Xms1g -Xmx2g -Xss2M"
-    SBT_OPTS: "-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=2g -Xmx2g"
+    JAVA_OPTS: "-XX:MaxMetaspaceSize=2g -Xms1g -Xmx2g -Xss2M -XX:+CMSClassUnloadingEnabled"
   volumes:
     - name: sbt-cache
       path: /root/.sbt

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ website/yarn.lock
 website/node_modules
 website/i18n/*
 
+.bsp
 .bloop
 .vscode
 .metals

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.7.2"
+version = "2.7.3"
 maxColumn = 80
 
 docstrings = JavaDoc

--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "co.fs2"               %%% "fs2-core"               % "2.4.4",
       "org.typelevel"        %%% "cats-effect"            % "2.2.0",
-      "com.eed3si9n.expecty" %%% "expecty"                % "0.13.0",
+      "com.eed3si9n.expecty" %%% "expecty"                % "0.14.0",
       "org.portable-scala"   %%% "portable-scala-reflect" % "1.0.0"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -78,10 +78,10 @@ lazy val root = project
     specs2JS)
   .configure(WeaverPlugin.profile)
   .settings(WeaverPlugin.doNotPublishArtifact)
-  .settings(
-    // Try really hard to not execute tasks in parallel
-    Global / concurrentRestrictions := Tags.limitAll(1) :: Nil
-  )
+// .settings(
+//   // Try really hard to not execute tasks in parallel
+// Global / concurrentRestrictions := Tags.limitAll(1) :: Nil
+// )
 
 lazy val core = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)

--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "co.fs2"               %%% "fs2-core"               % "2.4.4",
       "org.typelevel"        %%% "cats-effect"            % "2.2.0",
-      "com.eed3si9n.expecty" %%% "expecty"                % "0.14.0",
+      "com.eed3si9n.expecty" %%% "expecty"                % "0.14.1",
       "org.portable-scala"   %%% "portable-scala-reflect" % "1.0.0"
     )
   )

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -18,6 +18,7 @@ object MySuite2 extends SimpleIOSuite {
   }
 
   pureTest("Varargs composition") {
+    // expect(1 + 1 == 2) && expect (2 + 2 == 4) && expect(4 * 2 == 8)
     expect.all(1 + 1 == 2, 2 + 2 == 4, 4 * 2 == 8)
   }
 
@@ -39,6 +40,28 @@ object MySuite2 extends SimpleIOSuite {
       _ <- expect(h.nonEmpty).failFast
     } yield success
   }
+
+}
+```
+
+## Tracing locations of failed expectations
+
+As of 0.5.0, failed expectations carry a `NonEmptyList[SourceLocation]`, which can be used to manually trace the callsites that lead to a failure.
+
+By default, the very location where the expectation is created is captured, but the `traced` method can be use to add additional locations to the expectation.
+
+```scala mdoc
+object MySuite3 extends SimpleIOSuite {
+
+  pureTest("And/Or composition") {
+    foo
+  }
+
+  def foo(implicit loc : SourceLocation) = bar().traced(loc).traced(here)
+
+  def bar() = baz().traced(here)
+
+  def baz() = expect(1 != 1)
 
 }
 ```

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -17,6 +17,10 @@ object MySuite2 extends SimpleIOSuite {
     expect(1 != 2) and expect(2 != 1) or expect(2 != 3)
   }
 
+  pureTest("Varargs composition") {
+    expect.all(1 + 1 == 2, 2 + 2 == 4, 4 * 2 == 8)
+  }
+
   pureTest("Foldable operations") {
     val list = List(1,2,3)
     import cats.instances.list._

--- a/docs/multiple_suites_failures.md
+++ b/docs/multiple_suites_failures.md
@@ -19,14 +19,16 @@ object MySuite extends SimpleIOSuite {
 
 object MyAnotherSuite extends SimpleIOSuite {
   import scala.util.Random.alphanumeric
-  
+
   val randomString = IO(alphanumeric.take(10).mkString(""))
 
   simpleTest("failing test 2") {
     for {
       x <- randomString
-    } yield expect(x.length > 10)
+    } yield check(x).traced(here)
   }
+
+  def check(x : String) = expect(x.length > 10)
 }
 ```
 

--- a/modules/codecs/src/weaver/codecs/package.scala
+++ b/modules/codecs/src/weaver/codecs/package.scala
@@ -37,24 +37,14 @@ package object codecs {
   }
 
   implicit val sourceLocationEncoder: Encoder[SourceLocation] =
-    Encoder.forProduct4[SourceLocation,
-                        Option[String],
-                        Option[String],
-                        Option[String],
-                        Int](
-      "fileName",
+    Encoder.forProduct3[SourceLocation, String, String, Int](
       "filePath",
       "fileRelativePath",
       "line"
-    )(sl => (sl.fileName, sl.filePath, sl.fileRelativePath, sl.line))
+    )(sl => (sl.filePath, sl.fileRelativePath, sl.line))
 
   implicit val sourceLocationDecoder: Decoder[SourceLocation] =
-    Decoder.forProduct4[SourceLocation,
-                        Option[String],
-                        Option[String],
-                        Option[String],
-                        Int](
-      "fileName",
+    Decoder.forProduct3[SourceLocation, String, String, Int](
       "filePath",
       "fileRelativePath",
       "line"

--- a/modules/core/src/weaver/Expect.scala
+++ b/modules/core/src/weaver/Expect.scala
@@ -1,10 +1,9 @@
 package weaver
 
-import cats.data.ValidatedNel
+import cats.data.{NonEmptyList, ValidatedNel}
 import cats.syntax.all._
 
 import com.eed3si9n.expecty._
-import cats.data.NonEmptyList
 
 class Expect
     extends Recorder[Boolean, Expectations]

--- a/modules/core/src/weaver/Expect.scala
+++ b/modules/core/src/weaver/Expect.scala
@@ -1,7 +1,7 @@
 package weaver
 
-import cats.syntax.all._
 import cats.data.ValidatedNel
+import cats.syntax.all._
 
 import com.eed3si9n.expecty._
 

--- a/modules/core/src/weaver/Expect.scala
+++ b/modules/core/src/weaver/Expect.scala
@@ -1,6 +1,6 @@
 package weaver
 
-import cats.data.{NonEmptyList, ValidatedNel}
+import cats.data.{ NonEmptyList, ValidatedNel }
 import cats.syntax.all._
 
 import com.eed3si9n.expecty._

--- a/modules/core/src/weaver/Expect.scala
+++ b/modules/core/src/weaver/Expect.scala
@@ -4,6 +4,7 @@ import cats.data.ValidatedNel
 import cats.syntax.all._
 
 import com.eed3si9n.expecty._
+import cats.data.NonEmptyList
 
 class Expect
     extends Recorder[Boolean, Expectations]
@@ -14,8 +15,7 @@ class Expect
 
   class ExpectyListener extends RecorderListener[Boolean, Expectations] {
     def sourceLocation(loc: Location): SourceLocation = {
-      val name = loc.path.split("/").lastOption
-      SourceLocation(name, Some(loc.path), Some(loc.relativePath), loc.line)
+      SourceLocation(loc.path, loc.relativePath, loc.line)
     }
 
     override def expressionRecorded(
@@ -39,7 +39,8 @@ class Expect
                  else ": " + msg)
             val fullMessage = header + "\n\n" + rendering
             val sourceLoc   = sourceLocation(expr.location)
-            new AssertionException(fullMessage, sourceLoc).invalidNel
+            val sourceLocs  = NonEmptyList.of(sourceLoc)
+            new AssertionException(fullMessage, sourceLocs).invalidNel
           } else ().validNel
       }
       Expectations(res)

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -2,10 +2,9 @@ package weaver
 
 import cats._
 import cats.data.Validated._
-import cats.data.{ Validated, ValidatedNel }
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.effect.Sync
 import cats.syntax.all._
-import cats.data.NonEmptyList
 
 case class Expectations(val run: ValidatedNel[AssertionException, Unit]) {
   self =>

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -3,8 +3,8 @@ package weaver
 import cats._
 import cats.data.Validated._
 import cats.data.{ Validated, ValidatedNel }
-import cats.syntax.all._
 import cats.effect.Sync
+import cats.syntax.all._
 
 case class Expectations(val run: ValidatedNel[AssertionException, Unit]) {
   self =>

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -2,7 +2,7 @@ package weaver
 
 import cats._
 import cats.data.Validated._
-import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.data.{ NonEmptyList, Validated, ValidatedNel }
 import cats.effect.Sync
 import cats.syntax.all._
 

--- a/modules/core/src/weaver/exceptions.scala
+++ b/modules/core/src/weaver/exceptions.scala
@@ -1,6 +1,7 @@
 package weaver
 
 import scala.util.control.NonFatal
+import cats.data.NonEmptyList
 
 abstract class WeaverException(
     message: String,
@@ -20,8 +21,8 @@ sealed abstract class WeaverTestException(
 
 final case class AssertionException(
     message: String,
-    location: SourceLocation)
-    extends WeaverTestException(message, None, location)
+    locations: NonEmptyList[SourceLocation])
+    extends WeaverTestException(message, None, locations.head)
 
 final class IgnoredException(
     val reason: Option[String],

--- a/modules/core/src/weaver/exceptions.scala
+++ b/modules/core/src/weaver/exceptions.scala
@@ -18,9 +18,9 @@ sealed abstract class WeaverTestException(
     location: SourceLocation)
     extends WeaverException(message, cause, location)
 
-final class AssertionException(
-    val message: String,
-    val location: SourceLocation)
+final case class AssertionException(
+    message: String,
+    location: SourceLocation)
     extends WeaverTestException(message, None, location)
 
 final class IgnoredException(

--- a/modules/core/src/weaver/exceptions.scala
+++ b/modules/core/src/weaver/exceptions.scala
@@ -1,6 +1,7 @@
 package weaver
 
 import scala.util.control.NonFatal
+
 import cats.data.NonEmptyList
 
 abstract class WeaverException(

--- a/modules/core/src/weaver/suites.scala
+++ b/modules/core/src/weaver/suites.scala
@@ -25,7 +25,7 @@ trait Suite[F[_]] extends BaseSuiteClass {
 }
 
 // format: off
-trait EffectSuite[F[_]] extends Suite[F]{ self =>
+trait EffectSuite[F[_]] extends Suite[F] with SourceLocation.Here { self =>
 
   implicit def effect : Effect[F]
 

--- a/modules/core/src/weaver/suites.scala
+++ b/modules/core/src/weaver/suites.scala
@@ -48,9 +48,6 @@ trait EffectSuite[F[_]] extends Suite[F]{ self =>
   def run(args : List[String])(report : TestOutcome => IO[Unit]) : IO[Unit] =
     spec(args).evalMap(testOutcome => effect.liftIO(report(testOutcome))).compile.drain.toIO.adaptErr(adaptRunError)
 
-  implicit def singleExpectationConversion(e: SingleExpectation)(implicit loc: SourceLocation): F[Expectations] =
-    Expectations.fromSingle(e).pure[F]
-
   implicit def expectationsConversion(e: Expectations): F[Expectations] =
     e.pure[F]
 }

--- a/modules/framework/test/src/DogFoodTests.scala
+++ b/modules/framework/test/src/DogFoodTests.scala
@@ -122,7 +122,7 @@ object DogFoodSuite extends SimpleIOSuite with DogFood {
         |  of
         |  multiline
         |  (failure)
-        |  assertion failed (src/main/DogFoodTests.scala:5)
+        |  assertion failed (modules/framework/test/src/Meta.scala:30)
         |
         |  expect(1 == 2)
         |
@@ -220,7 +220,9 @@ object DogFoodSuite extends SimpleIOSuite with DogFood {
       .mkString("\n")
   }
 
-  private def expectEqual(expected: String, actual: String): Expectations = {
+  private def expectEqual(
+      expected: String,
+      actual: String)(implicit loc: SourceLocation): Expectations = {
     if (expected.trim != actual.trim) {
       val report = multiLineComparisonReport(expected.trim, actual.trim)
 

--- a/modules/framework/test/src/ExpectationsTests.scala
+++ b/modules/framework/test/src/ExpectationsTests.scala
@@ -21,4 +21,12 @@ object ExpectationsTests extends SimpleIOSuite {
     not(expect(2 == 1) xor expect(1 == 2))
   }
 
+  pureTest("all") {
+    expect.all(
+      1 == 1,
+      "a" + "b" == "ab",
+      true || false
+    )
+  }
+
 }

--- a/modules/framework/test/src/Meta.scala
+++ b/modules/framework/test/src/Meta.scala
@@ -136,9 +136,8 @@ object Meta {
     }
 
     implicit val sourceLocation: SourceLocation = SourceLocation(
-      Some("DogFoodTests.scala"),
-      None,
-      Some("src/main/DogFoodTests.scala"),
+      "src/main/DogFoodTests.scala",
+      "src/main/DogFoodTests.scala",
       5)
   }
 

--- a/modules/framework/test/src/TracingTests.scala
+++ b/modules/framework/test/src/TracingTests.scala
@@ -2,8 +2,7 @@ package weaver
 package framework
 package test
 
-import cats.data.Validated.Invalid
-import cats.data.Validated.Valid
+import cats.data.Validated.{ Invalid, Valid }
 
 object TracingTests extends SimpleIOSuite {
 

--- a/modules/framework/test/src/TracingTests.scala
+++ b/modules/framework/test/src/TracingTests.scala
@@ -27,10 +27,10 @@ object TracingTests extends SimpleIOSuite {
 
     result.run match {
       case Invalid(e) =>
-        val locations = e.head.location.toList
+        val locations = e.head.locations.toList
         val paths     = locations.map(_.fileRelativePath).map(standardise)
         forall(paths)(p => expect(p == thisFile)) &&
-        expect(locations.map(_.line) == List(38, 23, 24, 25))
+        expect(locations.map(_.line) == List(39, 24, 25, 26))
       case Valid(_) => failure("Should have been invalid")
     }
   }

--- a/modules/framework/test/src/TracingTests.scala
+++ b/modules/framework/test/src/TracingTests.scala
@@ -1,0 +1,41 @@
+package weaver
+package framework
+package test
+
+import cats.data.Validated.Invalid
+import cats.data.Validated.Valid
+
+object TracingTests extends SimpleIOSuite {
+
+  // Accommodate bloop
+  def standardise(path: String): String = {
+    val start = ("", 0)
+    val (result, _) = path.split("/").foldLeft(start) {
+      case ((path, count), "..")             => (path, count + 1)
+      case ((path, count), _) if (count > 0) => (path, count - 1)
+      case ((path, _), segment)              => (path + "/" + segment, 0)
+    }
+    result
+  }
+
+  val thisFile = "/modules/framework/test/src/TracingTests.scala"
+
+  test("Traces work as expected") {
+    val result = isOdd(2)
+      .traced(here)
+      .traced(here)
+
+    result.run match {
+      case Invalid(e) =>
+        val locations = e.head.location.toList
+        val paths     = locations.map(_.fileRelativePath).map(standardise)
+        forall(paths)(p => expect(p == thisFile)) &&
+        expect(locations.map(_.line) == List(38, 23, 24, 25))
+      case Valid(_) => failure("Should have been invalid")
+    }
+  }
+
+  def isOdd(i: Int)(implicit loc: SourceLocation): Expectations =
+    expect(i % 2 == 1).traced(loc)
+
+}

--- a/modules/framework/test/src/TracingTests.scala
+++ b/modules/framework/test/src/TracingTests.scala
@@ -29,7 +29,7 @@ object TracingTests extends SimpleIOSuite {
         val locations = e.head.locations.toList
         val paths     = locations.map(_.fileRelativePath).map(standardise)
         forall(paths)(p => expect(p == thisFile)) &&
-        expect(locations.map(_.line) == List(39, 24, 25, 26))
+        expect(locations.map(_.line).distinct.size == 4)
       case Valid(_) => failure("Should have been invalid")
     }
   }

--- a/modules/intellij-runner/src/weaver/intellij/runner/WeaverTestRunner.scala
+++ b/modules/intellij-runner/src/weaver/intellij/runner/WeaverTestRunner.scala
@@ -2,7 +2,7 @@ package weaver.intellij.runner
 
 import cats.effect.concurrent.Ref
 import cats.effect.{ ExitCode, IO, IOApp }
-import cats.implicits._
+import cats.syntax.all._
 
 import weaver._
 

--- a/modules/specs2/src/weaver/specs2compat/Matchers.scala
+++ b/modules/specs2/src/weaver/specs2compat/Matchers.scala
@@ -1,13 +1,12 @@
 package weaver.specs2compat
 
 import cats.Monoid
-import cats.data.Validated
+import cats.data.{NonEmptyList, Validated}
 import cats.effect.IO
 
 import weaver.{ AssertionException, EffectSuite, Expectations, SourceLocation }
 
 import org.specs2.matcher.{ MatchResult, MustMatchers }
-import cats.data.NonEmptyList
 
 trait Matchers[F[_]] extends MustMatchers {
   self: EffectSuite[F] =>

--- a/modules/specs2/src/weaver/specs2compat/Matchers.scala
+++ b/modules/specs2/src/weaver/specs2compat/Matchers.scala
@@ -7,6 +7,7 @@ import cats.effect.IO
 import weaver.{ AssertionException, EffectSuite, Expectations, SourceLocation }
 
 import org.specs2.matcher.{ MatchResult, MustMatchers }
+import cats.data.NonEmptyList
 
 trait Matchers[F[_]] extends MustMatchers {
   self: EffectSuite[F] =>
@@ -21,7 +22,7 @@ trait Matchers[F[_]] extends MustMatchers {
     } else {
       Expectations(Validated.invalidNel(new AssertionException(
         m.toResult.message,
-        pos)))
+        NonEmptyList.of(pos))))
     }
 
   implicit def toExpectationsF[A](

--- a/modules/specs2/src/weaver/specs2compat/Matchers.scala
+++ b/modules/specs2/src/weaver/specs2compat/Matchers.scala
@@ -1,7 +1,7 @@
 package weaver.specs2compat
 
 import cats.Monoid
-import cats.data.{NonEmptyList, Validated}
+import cats.data.{ NonEmptyList, Validated }
 import cats.effect.IO
 
 import weaver.{ AssertionException, EffectSuite, Expectations, SourceLocation }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0
+sbt.version=1.3.13


### PR DESCRIPTION
Update expecty to 0.14.0
    
* Source locations for "expect" are now sourced directly from the macro
* As a result, "SingleExpectation" is not needed anymore
* A new `expect.all` macro method allows to reduce boilerplate
* AssertionException now contains a (non-empty) list of locations.
* Expectations now has a "trace" method to append a location to all its errors.
* Addition of an "here" method that sources a location without being impacted by the implicit scope. 