### PR TITLE
[WIP] Start scalacheck-effect integration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -172,7 +172,8 @@ lazy val scalacheck = crossProject(JSPlatform, JVMPlatform)
   .settings(WeaverPlugin.simpleLayout)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scalacheck" %%% "scalacheck" % "1.14.3"
+      "org.scalacheck" %%% "scalacheck"        % "1.14.3",
+      "org.typelevel"  %%% "scalacheck-effect" % "0.2.0"
     ),
     scalaJSLinkerConfig ~= {
       _.withModuleKind(ModuleKind.CommonJSModule)

--- a/modules/scalacheck/src/weaver/scalacheck/ScalacheckF.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/ScalacheckF.scala
@@ -1,0 +1,70 @@
+package weaver
+package scalacheck
+
+import scala.util.control.NoStackTrace
+
+import cats.data.Validated.{Invalid, Valid}
+import cats.effect.IO
+import cats.syntax.all._
+
+import Expectations.Helpers._
+import org.scalacheck.Test.{Exhausted, Failed, Passed, PropException, Proved}
+import org.scalacheck.effect.PropF
+import org.scalacheck.util.Pretty
+
+import org.scalacheck.Prop.Arg
+
+trait ScalacheckIO extends ScalacheckF[IO] {
+  self: MutableFSuite[IO] =>
+}
+
+case class Falsified(args: List[Arg[Any]], causedBy: Throwable)
+    extends Exception("", causedBy)
+    with NoStackTrace {
+  override def toString(): String =
+    """
+        |Property falsified for the following arguments:
+        |
+        """.stripMargin + renderArguments
+
+  private def renderArguments = {
+    args.zipWithIndex.map { case (arg, i) =>
+      val lab = if (arg.label == "") "ARG_" + i.toString() else arg.label
+      lab + ": " + arg.prettyArg.apply(Pretty.Params(1))
+    }.mkString("\n")
+  }
+
+  override def getMessage(): String = toString()
+}
+
+trait ScalacheckF[F[_]] { self: MutableFSuite[F] =>
+
+  implicit def toPropF: IO[Expectations] => PropF[IO] = { expectations =>
+    PropF.effectOfPropFToPropF(
+      expectations.map(toProp)
+    )
+  }
+
+  implicit def toProp: Expectations => PropF[IO] = { expectations =>
+    expectations.run match {
+      case Invalid(e) => PropF.exception(e.head)
+      case Valid(_)   => PropF.passed
+    }
+  }
+
+  def propTest(name: TestName)(f: PropF[F])(implicit sl: SourceLocation) = {
+    simpleTest(name) {
+      f.check().flatMap { result =>
+        result.status match {
+          case Exhausted => failure("Exhausted")
+          case Proved(_) => success
+          case Passed    => success
+          case PropException(args, e, _) =>
+            Falsified(args, e).raiseError[F, Expectations]
+          case Failed(args, _) =>
+            Falsified(args, null).raiseError[F, Expectations]
+        }
+      }
+    }
+  }
+}

--- a/modules/scalacheck/test/src/weaver/scalacheck/ScalacheckFTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/ScalacheckFTest.scala
@@ -1,0 +1,49 @@
+package weaver
+package scalacheck
+
+import scala.util.control.NoStackTrace
+
+import cats.effect.IO
+
+import org.scalacheck.effect.PropF
+
+object ScalacheckFTest extends SimpleIOSuite with ScalacheckIO {
+  propTest("successes") {
+    PropF.forAllF { (x: Int) =>
+      IO(x).start.flatMap(_.join).map(_ => PropF.passed[IO])
+    }
+  }
+
+  propTest("falsified") {
+    PropF.forAllF { (x: Int) =>
+      IO(x).start.flatMap(_.join).map(_ => PropF.falsified[IO])
+    }
+  }
+
+  propTest("exception") {
+    PropF.forAllF { (x: Int) =>
+      IO(x).start.flatMap(_.join).map(_ =>
+        PropF.exception[IO](new RuntimeException("whaaat") with NoStackTrace))
+    }
+  }
+
+  propTest("If it's above 250, it should be even") {
+    PropF.forAllF { (x: Int) =>
+      if (x > 250) expect(x % 2 == 0)
+      else success
+    }
+  }
+
+  propTest("Basic arithmetics") {
+    PropF.forAllF { (x: Int) =>
+      expect(x - x == 0)
+    }
+  }
+
+  propTest("Basic arithmetics (but with Fibers)") {
+    PropF.forAllF { (x: Int) =>
+      IO(x).start.flatMap(_.join).as(expect(x - x == 0))
+    }
+  }
+
+}


### PR DESCRIPTION
Closes #79 

This is just a WIP.

I want to discuss what sort of UX we present to the user of those traits, how we can make the rendering of failures better (tbh I actually like a combination of expecty's output and argument output)

![image](https://user-images.githubusercontent.com/1052965/96494254-040a7a80-123e-11eb-92af-3c1942ace710.png)

My issue here is mostly the source location being super wrong.

And also the amount of configuration for Scalacheck we expose on a per-test/per-spec basis.