### PR TITLE
Render build matrix in the docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import sbt.internal.ProjectMatrix
 import WeaverPlugin._
 
 ThisBuild / commands += Command.command("ci") { state =>

--- a/build.sbt
+++ b/build.sbt
@@ -29,26 +29,6 @@ ThisBuild / scalaVersion := WeaverPlugin.scala213
 
 ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.4.4"
 
-lazy val dumpBuildMatrix = taskKey[Unit]("")
-
-val allEffectCoresFilter: ScopeFilter =
-  ScopeFilter(
-    inProjects(effectFrameworks: _*),
-    inConfigurations(Compile)
-  )
-
-val allIntegrationsCoresFilter: ScopeFilter =
-  ScopeFilter(
-    inProjects((scalacheck.projectRefs ++ specs2.projectRefs): _*),
-    inConfigurations(Compile)
-  )
-
-ThisBuild / dumpBuildMatrix := {
-  val x = scalaVersion.all(allEffectCoresFilter).value
-
-  println(x)
-}
-
 Global / (Test / fork) := true
 Global / (Test / testOptions) += Tests.Argument("--quickstart")
 
@@ -113,6 +93,18 @@ lazy val core = projectMatrix
 lazy val projectsWithAxes = Def.task {
   (name.value, virtualAxes.value, version.value)
 }
+
+val allEffectCoresFilter: ScopeFilter =
+  ScopeFilter(
+    inProjects(effectFrameworks: _*),
+    inConfigurations(Compile)
+  )
+
+val allIntegrationsCoresFilter: ScopeFilter =
+  ScopeFilter(
+    inProjects((scalacheck.projectRefs ++ specs2.projectRefs): _*),
+    inConfigurations(Compile)
+  )
 
 lazy val docs = projectMatrix
   .in(file("modules/docs"))

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,8 @@ lazy val allModules = Seq(
   effectFrameworks
 ).flatten
 
+lazy val catsEffect3Version = "3.0.0-M4"
+
 def catsEffectDependencies(proj: Project): Project = {
   proj.settings(
     libraryDependencies ++= {
@@ -59,7 +61,7 @@ def catsEffectDependencies(proj: Project): Project = {
       else
         Seq(
           "co.fs2"        %%% "fs2-core"    % "3.0.0-M6",
-          "org.typelevel" %%% "cats-effect" % "3.0.0-M4"
+          "org.typelevel" %%% "cats-effect" % catsEffect3Version
         )
     }
   )
@@ -161,6 +163,7 @@ lazy val docs = projectMatrix
         | package weaver.docs
         |
         | object BuildMatrix {
+        |    val catsEffect3Version = ${q(catsEffect3Version)}
         |    val effects = $effects
         |    val integrations = $integrations
         | }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,8 +5,8 @@ title: Installation
 
 All of the artifacts from the table below are:
 
-1. Available for Scala 2.12 and 2.13
-2. Available for JVM and Scala.js
+1. Available for **Scala 2.12 and 2.13**
+2. Available for **JVM and Scala.js**
 
 ```scala mdoc:passthrough
 import weaver.docs._

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,8 +11,13 @@ All of the artifacts from the table below are:
 ```scala mdoc:passthrough
 import weaver.docs._
 
-val effects = Table.create("Effect types", BuildMatrix.effects).render
-val integrations = Table.create("Integrations", BuildMatrix.integrations).render
+val effects = Table
+    .create("Effect types", BuildMatrix.effects)
+    .render(BuildMatrix.catsEffect3Version)
+    
+val integrations = Table
+    .create("Integrations", BuildMatrix.integrations)
+    .render(BuildMatrix.catsEffect3Version)
 
 println(effects)
 println(integrations)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,20 @@ id: installation
 title: Installation
 ---
 
-Weaver-test is currently published for **Scala 2.12 and 2.13**
+All of the artifacts from the table below are:
+
+1. Available for Scala 2.12 and 2.13
+2. Available for JVM and Scala.js
+
+```scala mdoc:passthrough
+import weaver.docs._
+
+val effects = Table.create("Effect types", BuildMatrix.effects).render
+val integrations = Table.create("Integrations", BuildMatrix.integrations).render
+
+println(effects)
+println(integrations)
+```
 
 Weaver offers effect-type specific test frameworks. The Build setup depends on
 the effect-type library you've elected to use (or test against).
@@ -14,4 +27,3 @@ Refer yourself to the library specific pages to get the correct configuration.
 * [monix](monix_usage.md)
 * [monix-bio](monix_bio_usage.md)
 * [zio](zio_usage.md)
-

--- a/modules/docs/src/main/scala/weaver/MatrixRendering.scala
+++ b/modules/docs/src/main/scala/weaver/MatrixRendering.scala
@@ -41,7 +41,7 @@ case class Table(
       case Some(c) =>
         if (c.jvm && c.js) {
           s"✅ `${c.version}`"
-        } else c.toString()
+        } else "❌" // TODO: do we always assume platform-complete artifacts?
       case None => "❌"
     }
   }
@@ -83,7 +83,7 @@ object Table {
 
   def create(name: String, artifacts: List[Artifact]): Table = {
 
-    val grouped = artifacts.groupBy(g => g.name)
+    val grouped = artifacts.groupBy(_.name)
 
     val rows = grouped.map {
       case (name, artifacts) =>

--- a/modules/docs/src/main/scala/weaver/MatrixRendering.scala
+++ b/modules/docs/src/main/scala/weaver/MatrixRendering.scala
@@ -46,9 +46,9 @@ case class Table(
     }
   }
 
-  def render = {
+  def render(catsEffect3Version: String) = {
     val sb = new StringBuilder
-    sb.append(_row(Seq(name, "Cats Effect 2", "Cats Effect 3"), header = true))
+    sb.append(_row(Seq(name, "Cats Effect 2", s"Cats Effect $catsEffect3Version"), header = true))
 
     rows.map { case Row(name, ce2, ce3) =>
       sb.append(_row(Seq(name, _cell(ce2), _cell(ce3))))

--- a/modules/docs/src/main/scala/weaver/MatrixRendering.scala
+++ b/modules/docs/src/main/scala/weaver/MatrixRendering.scala
@@ -1,0 +1,105 @@
+package weaver.docs
+
+sealed trait CatsEffect
+case object CE2 extends CatsEffect
+case object CE3 extends CatsEffect
+
+case class Artifact(
+    name: String,
+    jvm: Boolean,
+    js: Boolean,
+    scalaVersion: String,
+    catsEffect: CatsEffect,
+    version: String
+)
+
+case class Cell(
+    jvm: Boolean,
+    js: Boolean,
+    version: String
+)
+
+case class Row(
+    name: String,
+    ce2: Option[Cell],
+    ce3: Option[Cell]
+)
+
+case class Table(
+    name: String,
+    rows: Vector[Row]
+) {
+  def _row(l: Seq[String], header: Boolean = false): String = {
+    val base = l.mkString("|", "|", "|")
+
+    if (header) base + "\n" + _row(l.map(_ => "---"), false)
+    else base + "\n"
+  }
+
+  def _cell(c: Option[Cell]): String = {
+    c match {
+      case Some(c) =>
+        if (c.jvm && c.js) {
+          s"✅ `${c.version}`"
+        } else c.toString()
+      case None => "❌"
+    }
+  }
+
+  def render = {
+    val sb = new StringBuilder
+    sb.append(_row(Seq(name, "Cats Effect 2", "Cats Effect 3"), header = true))
+
+    rows.map { case Row(name, ce2, ce3) =>
+      sb.append(_row(Seq(name, _cell(ce2), _cell(ce3))))
+    }
+    sb.result()
+  }
+}
+
+object Table {
+  def row_name(artif: String) = artif match {
+    case "cats"       => "Cats-Effect"
+    case "zio"        => "ZIO"
+    case "monix"      => "Monix"
+    case "monix-bio"  => "Monix BIO"
+    case "scalacheck" => "ScalaCheck"
+    case "specs2"     => "Specs2 matchers"
+    case _            => throw new RuntimeException("Not another effect type!")
+  }
+
+  def artifactsToCell(artifacts: List[Artifact]): Option[Cell] = {
+    artifacts.map(_.version).distinct.headOption.map { version =>
+      val hasJVM = artifacts.exists(_.jvm)
+      val hasJS  = artifacts.exists(_.js)
+
+      Cell(
+        jvm = hasJVM,
+        js = hasJS,
+        version = version
+      )
+    }
+  }
+
+  def create(name: String, artifacts: List[Artifact]): Table = {
+
+    val grouped = artifacts.groupBy(g => g.name)
+
+    val rows = grouped.map {
+      case (name, artifacts) =>
+        val rowName = row_name(name)
+
+        val ce2Artifacts = artifacts.filter(_.catsEffect == CE2)
+        val ce3Artifacts = artifacts.filter(_.catsEffect == CE3)
+
+        Row(rowName,
+            artifactsToCell(ce2Artifacts),
+            artifactsToCell(ce3Artifacts))
+    }
+
+    Table(
+      name,
+      rows.toVector.sortBy(_.name)
+    )
+  }
+}


### PR DESCRIPTION
1. Dump artifacts in a folder where mdoc can pick it up
2. Add rendering logic

Example from this branch: http://weaver-site.surge.sh/weaver-test/docs/installation

**Questions:**

 - [ ] Handle incomplete cells (i.e. not all scala versions / not all platforms)
 - [ ] Add more text?
 - [ ] Add links to mvnrepository.com? i.e. make each version a link to a 2.13 JVM artifact, i.e. https://mvnrepository.com/artifact/com.disneystreaming/weaver-zio_2.13/0.6.0-M1