### PR TITLE
Adds support for memoised resources

### DIFF
--- a/modules/core/src-ce2/weaver/CECompat.scala
+++ b/modules/core/src-ce2/weaver/CECompat.scala
@@ -14,6 +14,9 @@ private[weaver] trait CECompat {
   private[weaver] type Ref[F[_], A] = cats.effect.concurrent.Ref[F, A]
   private[weaver] val Ref = cats.effect.concurrent.Ref
 
+  private[weaver] type Deferred[F[_], A] = cats.effect.concurrent.Deferred[F, A]
+  private[weaver] val Deferred = cats.effect.concurrent.Deferred
+
   private[weaver] type Semaphore[F[_]] = cats.effect.concurrent.Semaphore[F]
   private[weaver] val Semaphore = cats.effect.concurrent.Semaphore
 

--- a/modules/core/src-ce2/weaver/MemoisedResource.scala
+++ b/modules/core/src-ce2/weaver/MemoisedResource.scala
@@ -1,0 +1,55 @@
+package weaver
+
+import cats.effect._
+import cats.effect.concurrent.{Deferred, Ref}
+import cats.syntax.all._
+
+object MemoisedResource {
+  def apply[F[_]: Concurrent, A](
+      resource: Resource[F, A]): F[Resource[F, A]] =
+    new MemoisedResource[F, A].apply(resource)
+}
+
+private class MemoisedResource[F[_]: Concurrent, A] {
+
+  sealed trait State
+  case object Uninitialised extends State
+  case class InUse(value: Deferred[F, A], finalizer: F[Unit], uses: Int)
+      extends State
+
+  def apply(resource: Resource[F, A]): F[Resource[F, A]] =
+    Ref[F].of[State](Uninitialised).map { ref =>
+      val initialise: F[A] = for {
+        valuePromise     <- Deferred[F, A]
+        finaliserPromise <- Deferred[F, F[Unit]]
+        compute <- ref.modify {
+          case Uninitialised =>
+            val newState = InUse(valuePromise, finaliserPromise.get.flatten, 1)
+            val compute = for {
+              (a, fin) <- resource.allocated
+              _        <- valuePromise.complete(a)
+              _        <- finaliserPromise.complete(fin)
+            } yield a
+            newState -> compute
+          case InUse(value, finalizer, uses) =>
+            val newState      = InUse(value, finalizer, uses + 1)
+            val compute: F[A] = value.get
+            newState -> compute
+        }
+        value <- compute
+      } yield value
+
+      val finalise: F[Unit] = ref.modify[F[Unit]] {
+        case Uninitialised =>
+          Uninitialised -> Concurrent[F].raiseError(
+            new IllegalStateException("Implementation error"))
+        case InUse(_, finaliser, n) if n <= 1 =>
+          Uninitialised -> finaliser
+        case InUse(value, finaliser, n) =>
+          InUse(value, finaliser, n - 1) -> Concurrent[F].unit
+      }.flatten
+
+      Resource.make(initialise)(_ => finalise)
+    }
+
+}

--- a/modules/core/src-ce3/weaver/CECompat.scala
+++ b/modules/core/src-ce3/weaver/CECompat.scala
@@ -15,6 +15,9 @@ private[weaver] trait CECompat {
   private[weaver] type Ref[F[_], A] = cats.effect.kernel.Ref[F, A]
   private[weaver] val Ref = cats.effect.kernel.Ref
 
+  private[weaver] type Deferred[F[_], A] = cats.effect.kernel.Deferred[F, A]
+  private[weaver] val Deferred = cats.effect.kernel.Deferred
+
   private[weaver] type Semaphore[F[_]] = cats.effect.std.Semaphore[F]
   private[weaver] val Semaphore = cats.effect.std.Semaphore
 

--- a/modules/core/src/weaver/MemoisedResource.scala
+++ b/modules/core/src/weaver/MemoisedResource.scala
@@ -29,7 +29,7 @@ private class MemoisedResource[F[_]: Concurrent, A] {
         compute <- ref.modify {
           case Uninitialised =>
             val newState = InUse(valuePromise, finaliserPromise.get.flatten, 1)
-            val compute = resource.allocated.attempt.flatMap {
+            val compute = Concurrent[F].attempt(resource.allocated).flatMap {
               case Right((a, fin)) => for {
                   _ <- valuePromise.complete(Right(a))
                   _ <- finaliserPromise.complete(fin)

--- a/modules/core/src/weaver/MemoisedResource.scala
+++ b/modules/core/src/weaver/MemoisedResource.scala
@@ -37,6 +37,7 @@ private class MemoisedResource[F[_]: Concurrent, A] {
               case Left(e) => for {
                   _ <- valuePromise.complete(Left(e))
                   _ <- finaliserPromise.complete(Concurrent[F].unit)
+                  _ <- ref.set(Uninitialised) // reset state
                   a <- Concurrent[F].raiseError[A](e)
                 } yield a
             }

--- a/modules/framework/cats/test/src-jvm/DogFoodTestsJVM.scala
+++ b/modules/framework/cats/test/src-jvm/DogFoodTestsJVM.scala
@@ -4,6 +4,7 @@ package test
 
 import cats.effect.{ IO, Resource }
 import cats.syntax.all._
+
 import sbt.testing.Status
 
 object DogFoodTestsJVM extends IOSuite {

--- a/modules/framework/cats/test/src-jvm/DogFoodTestsJVM.scala
+++ b/modules/framework/cats/test/src-jvm/DogFoodTestsJVM.scala
@@ -4,6 +4,7 @@ package test
 
 import cats.effect.{ IO, Resource }
 import cats.syntax.all._
+import sbt.testing.Status
 
 object DogFoodTestsJVM extends IOSuite {
 
@@ -40,6 +41,40 @@ object DogFoodTestsJVM extends IOSuite {
           expect(errorCount == 1) && expect(!file.exists())
         }
     }
+  }
+
+  test("global lazy resources (parallel)") { dogfood =>
+    import dogfood._
+    runSuites(
+      globalInit(MetaJVM.LazyGlobal),
+      sharingSuite[MetaJVM.LazyAccessParallel],
+      sharingSuite[MetaJVM.LazyAccessParallel],
+      sharingSuite[MetaJVM.LazyAccessParallel]
+    ).map {
+      case (_, events) =>
+        val successCount = events.toList.map(_.status()).count {
+          case Status.Success => true; case _ => false
+        }
+        expect(successCount == 3)
+    }
+
+  }
+
+  test("global lazy resources (sequential)") { dogfood =>
+    import dogfood._
+    runSuites(
+      globalInit(MetaJVM.LazyGlobal),
+      sharingSuite[MetaJVM.LazyAccessSequential0],
+      sharingSuite[MetaJVM.LazyAccessSequential1],
+      sharingSuite[MetaJVM.LazyAccessSequential2]
+    ).map {
+      case (_, events) =>
+        val successCount = events.toList.map(_.status()).count {
+          case Status.Success => true; case _ => false
+        }
+        expect(successCount == 3)
+    }
+
   }
 
 }

--- a/modules/framework/cats/test/src-jvm/MetaJVM.scala
+++ b/modules/framework/cats/test/src-jvm/MetaJVM.scala
@@ -5,6 +5,7 @@ package test
 import java.io.File
 
 import cats.effect._
+import scala.concurrent.duration._
 
 // The build tool will only detect and run top-level test suites. We can however nest objects
 // that contain failing tests, to allow for testing the framework without failing the build
@@ -38,5 +39,82 @@ object MetaJVM {
   object SetTimeUnsafeRun extends CatsUnsafeRun {
     override def realTimeMillis: IO[Long] = IO.pure(0L)
   }
+
+  class LazyState(
+      initialised: IO[Int],
+      finalised: IO[Int],
+      totalUses: CECompat.Ref[IO, Int],
+      uses: CECompat.Ref[IO, Int]) {
+    val getState: IO[(Int, Int, Int, Int)] = for {
+      i <- initialised
+      f <- finalised
+      t <- totalUses.updateAndGet(_ + 1)
+      u <- uses.updateAndGet(_ + 1)
+    } yield (i, f, t, u)
+  }
+
+  object LazyGlobal extends GlobalResource {
+    def sharedResources(global: weaver.GlobalWrite): Resource[IO, Unit] =
+      CECompat.resourceLift {
+        for {
+          initialised <- CECompat.Ref[IO].of(0)
+          finalised   <- CECompat.Ref[IO].of(0)
+          totalUses   <- CECompat.Ref[IO].of(0)
+          resource =
+            CECompat.resourceLift(CECompat.Ref[IO].of(0)).flatMap { uses =>
+              Resource.make(initialised.update(_ + 1))(_ =>
+                finalised.update(_ + 1)).map(_ =>
+                new LazyState(initialised.get, finalised.get, totalUses, uses))
+            }
+          _ <- global.putLazy(resource)
+        } yield ()
+      }
+  }
+
+  class LazyAccessParallel(global: GlobalRead) extends IOSuite {
+    type Res = LazyState
+    def sharedResource: Resource[IO, Res] = global.getOrFailR[LazyState]()
+
+    test("Lazy resources should be instantiated only once") { state =>
+      IO.sleep(100.millis) *> state.getState.map {
+        case (initialised, finalised, totalUses, localUses) =>
+          expect.all(
+            initialised == 1, // resource is initialised only once and uses in parallel
+            finalised == 0,   // resource is not finalised until all parallel uses are completed
+            totalUses >= 1,
+            totalUses <= 3,
+            localUses >= 1,
+            localUses <= 3
+          )
+      }
+    }
+  }
+
+  abstract class LazyAccessSequential(global: GlobalRead, index: Int)
+      extends IOSuite {
+    type Res = LazyState
+    def sharedResource: Resource[IO, Res] =
+      CECompat.resourceLift(IO.sleep(index * 500.millis)).flatMap(_ =>
+        global.getOrFailR[LazyState]())
+
+    test("Lazy resources should be instantiated several times") { state =>
+      state.getState.map {
+        case (initialised, finalised, totalUses, localUses) =>
+          expect.all(
+            initialised == totalUses, // lazy resource will get initialised for each suite
+            finalised == totalUses - 1,
+            localUses == 1 // one test for each inialisation
+          )
+      }
+    }
+  }
+
+  // Using sleeps to force sequential runs of suites
+  class LazyAccessSequential0(global: GlobalRead)
+      extends LazyAccessSequential(global, 0)
+  class LazyAccessSequential1(global: GlobalRead)
+      extends LazyAccessSequential(global, 1)
+  class LazyAccessSequential2(global: GlobalRead)
+      extends LazyAccessSequential(global, 2)
 
 }

--- a/modules/framework/cats/test/src-jvm/MetaJVM.scala
+++ b/modules/framework/cats/test/src-jvm/MetaJVM.scala
@@ -4,8 +4,9 @@ package test
 
 import java.io.File
 
-import cats.effect._
 import scala.concurrent.duration._
+
+import cats.effect._
 
 // The build tool will only detect and run top-level test suites. We can however nest objects
 // that contain failing tests, to allow for testing the framework without failing the build

--- a/modules/framework/cats/test/src/MemoisedResourceTests.scala
+++ b/modules/framework/cats/test/src/MemoisedResourceTests.scala
@@ -2,11 +2,12 @@ package weaver
 package framework
 package test
 
-import CECompat.Ref
+import scala.concurrent.duration._
+
 import cats.effect._
 import cats.syntax.all._
 
-import scala.concurrent.duration._
+import CECompat.Ref
 
 object MemoisedResourceTests extends SimpleIOSuite {
 

--- a/modules/framework/cats/test/src/MemoisedResourceTests.scala
+++ b/modules/framework/cats/test/src/MemoisedResourceTests.scala
@@ -1,0 +1,35 @@
+package weaver
+package framework
+package test
+
+import cats.effect.concurrent.Ref
+import cats.effect._
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+object MemoisedResourceTests extends SimpleIOSuite {
+
+  test("""|Memoised resources should be:
+          | * lazily allocated,
+          | * shared when accessed concurrently
+          | * not finalised until all uses are finished
+          | * re-allocated on demand after being finalised""".stripMargin) {
+    for {
+      initalised <- Ref[IO].of(0)
+      finalised  <- Ref[IO].of(0)
+      used       <- Ref[IO].of(0)
+      resource =
+        Resource.make(initalised.update(_ + 1))(_ => finalised.update(_ + 1))
+      use <- MemoisedResource(resource).map(r =>
+        r.use(_ => IO.sleep(100.millis) *> used.update(_ + 1)))
+      _         <- use
+      _         <- List.fill(10)(use).parSequence
+      _         <- use
+      initCount <- initalised.get
+      finCount  <- finalised.get
+      useCount  <- used.get
+    } yield expect.all(initCount == 3, finCount == 3, useCount == 12)
+  }
+
+}

--- a/modules/framework/cats/test/src/MemoisedResourceTests.scala
+++ b/modules/framework/cats/test/src/MemoisedResourceTests.scala
@@ -2,7 +2,7 @@ package weaver
 package framework
 package test
 
-import cats.effect.concurrent.Ref
+import CECompat.Ref
 import cats.effect._
 import cats.syntax.all._
 

--- a/modules/framework/cats/test/src/MemoisedResourceTests.scala
+++ b/modules/framework/cats/test/src/MemoisedResourceTests.scala
@@ -16,17 +16,17 @@ object MemoisedResourceTests extends SimpleIOSuite {
           | * not finalised until all uses are finished
           | * re-allocated on demand after being finalised""".stripMargin) {
     for {
-      initalised <- Ref[IO].of(0)
-      finalised  <- Ref[IO].of(0)
-      used       <- Ref[IO].of(0)
+      initialised <- Ref[IO].of(0)
+      finalised   <- Ref[IO].of(0)
+      used        <- Ref[IO].of(0)
       resource =
-        Resource.make(initalised.update(_ + 1))(_ => finalised.update(_ + 1))
+        Resource.make(initialised.update(_ + 1))(_ => finalised.update(_ + 1))
       use <- MemoisedResource(resource).map(r =>
         r.use(_ => IO.sleep(100.millis) *> used.update(_ + 1)))
       _         <- use
       _         <- List.fill(10)(use).parSequence
       _         <- use
-      initCount <- initalised.get
+      initCount <- initialised.get
       finCount  <- finalised.get
       useCount  <- used.get
     } yield expect.all(initCount == 3, finCount == 3, useCount == 12)


### PR DESCRIPTION
This adds a construct allowing for lazy allocation/eager de-allocation of resources, which could come handy when users use global resources to keep computationally heavy constructs in the background (distributed log consumers, and so on). 

It is currently not cancel-safe, but I intend to specialise it to CE2/CE3 in a later unit of work 