### PR TITLE
Remove problematic implicit lift to F

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ object MySuite extends SimpleIOSuite {
 
   private val random = IO(java.util.UUID.randomUUID())
 
-  simpleTest("test with side-effects") {
+  test("test with side-effects") {
     for {
       x <- random
       y <- random
@@ -200,7 +200,7 @@ import weaver.scalacheck._
 // Notice the IOCheckers mix-in
 object ForallExamples extends SimpleIOSuite with IOCheckers {
 
-  simpleTest("Gen form") {
+  test("Gen form") {
     // Takes an explicit "Gen" instance. There is only a single
     // version of this overload. If you want to pass several Gen instances
     // at once, just compose them monadically.
@@ -209,7 +209,7 @@ object ForallExamples extends SimpleIOSuite with IOCheckers {
     }
   }
 
-  simpleTest("Arbitrary form") {
+  test("Arbitrary form") {
     // Takes a number of implicit "Arbitrary" instances. There are 6 overloads
     // to pass 1 to 6 parameters.
     forall { (a1: Int, a2: Int, a3: Int) =>

--- a/docs/cats_effect_usage.md
+++ b/docs/cats_effect_usage.md
@@ -44,7 +44,7 @@ object MySuite extends SimpleIOSuite {
   val randomUUID = IO(java.util.UUID.randomUUID())
 
   // A test for side-effecting functions
-  simpleTest("hello side-effects") {
+  test("hello side-effects") {
     for {
       x <- randomUUID
       y <- randomUUID

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -34,7 +34,7 @@ object MySuite2 extends SimpleIOSuite {
     if (condition) success else failure("Condition failed")
   }
 
-  simpleTest("Failing fast expectations") {
+  test("Failing fast expectations") {
     for {
       h <- IO.pure("hello")
       _ <- expect(h.nonEmpty).failFast

--- a/docs/monix_bio_usage.md
+++ b/docs/monix_bio_usage.md
@@ -41,7 +41,7 @@ object MySuite extends SimpleIOSuite {
 
   val randomUUID = Task(java.util.UUID.randomUUID())  // Use of `Task` instead of `IO`
 
-  simpleTest("hello side-effects") {
+  test("hello side-effects") {
     for {
       x <- randomUUID
       y <- randomUUID

--- a/docs/monix_usage.md
+++ b/docs/monix_usage.md
@@ -37,7 +37,7 @@ object MySuite extends SimpleTaskSuite {
 
   val randomUUID = Task(java.util.UUID.randomUUID())  // Use of `Task` instead of `IO`
 
-  simpleTest("hello side-effects") {
+  test("hello side-effects") {
     for {
       x <- randomUUID
       y <- randomUUID

--- a/docs/multiple_suites_failures.md
+++ b/docs/multiple_suites_failures.md
@@ -12,7 +12,7 @@ import cats.effect._
 object MySuite extends SimpleIOSuite {
   val randomUUID = IO(java.util.UUID.randomUUID())
 
-  simpleTest("failing test 1") {
+  pureTest("failing test 1") {
     expect(1 >= 2)
   }
 }
@@ -22,7 +22,7 @@ object MyAnotherSuite extends SimpleIOSuite {
 
   val randomString = IO(alphanumeric.take(10).mkString(""))
 
-  simpleTest("failing test 2") {
+  test("failing test 2") {
     for {
       x <- randomString
     } yield check(x).traced(here)

--- a/docs/multiple_suites_success.md
+++ b/docs/multiple_suites_success.md
@@ -16,7 +16,7 @@ object MySuite extends SimpleIOSuite {
 
   val randomUUID = IO(java.util.UUID.randomUUID())
 
-  simpleTest("hello side-effects") {
+  test("hello side-effects") {
     for {
       x <- randomUUID
       y <- randomUUID
@@ -30,7 +30,7 @@ object MyAnotherSuite extends SimpleIOSuite {
 
   val randomString = IO(alphanumeric.take(10).mkString(""))
 
-  simpleTest("double reversing is identity") {
+  test("double reversing is identity") {
     for {
       x <- randomString
     } yield expect(x == x.reverse.reverse)

--- a/docs/scalacheck.md
+++ b/docs/scalacheck.md
@@ -36,7 +36,7 @@ import weaver.scalacheck._
 object ForallExamples extends SimpleIOSuite with Checkers {
 
   // Using a single `Gen` instance
-  simpleTest("Single Gen form") {
+  test("Single Gen form") {
     // Takes a single, explicit `Gen` instance
     forall(Gen.posNum[Int]) { a =>
       expect(a > 0)
@@ -45,7 +45,7 @@ object ForallExamples extends SimpleIOSuite with Checkers {
 
   // There is only one overload for the `forall` that takes an explicit `Gen` parameter
   // To use multiple `Gen` instances, compose them monadically before passing to `forall`
-  simpleTest("Multiple Gen form") {
+  test("Multiple Gen form") {
     // Compose into a single `Gen[(Int, Int)]`
     val gen = for {
       a <- Gen.posNum[Int]
@@ -59,7 +59,7 @@ object ForallExamples extends SimpleIOSuite with Checkers {
   }
 
   // Using a number of `Arbitrary` instances
-  simpleTest("Arbitrary form") {
+  test("Arbitrary form") {
     // There are 6 overloads, to pass 1-6 parameters
     forall { (a1: Int, a2: Int, a3: Int) =>
       expect(a1 * a2 * a3 == a3 * a2 * a1)

--- a/docs/specs2.md
+++ b/docs/specs2.md
@@ -49,19 +49,19 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
     1 === 1
   }
 
-  simpleTest("simpleTest { 1 must beEqualTo(1) }") {
+  pureTest("pureTest { 1 must beEqualTo(1) }") {
     1 must beEqualTo(1)
   }
 
-  simpleTest("simpleTest { 1 must be_==(1) }") {
+  pureTest("pureTest { 1 must be_==(1) }") {
     1 must be_==(1)
   }
 
-  simpleTest("simpleTest { 1 mustEqual 1 }") {
+  pureTest("pureTest { 1 mustEqual 1 }") {
     1 mustEqual 1
   }
 
-  simpleTest("simpleTest { 1 === 1 }") {
+  pureTest("pureTest { 1 === 1 }") {
     1 === 1
   }
 }

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -12,7 +12,7 @@ import cats.syntax.all._
 
 object MySuite extends SimpleIOSuite {
 
-  simpleTest("Only on CI") {
+  test("Only on CI") {
     for {
       onCI <- IO(sys.env.get("CI").isDefined)
       _    <- ignore("not on CI").unlessA(onCI)
@@ -21,7 +21,7 @@ object MySuite extends SimpleIOSuite {
     } yield expect(x == y)
   }
 
-  simpleTest("Another on CI") {
+  test("Another on CI") {
     for {
       onCI <- IO(sys.env.get("CI").isDefined)
       _    <- cancel("not on CI").unlessA(onCI)

--- a/modules/codecs/test/src/weaver/codecs/CodecsTest.scala
+++ b/modules/codecs/test/src/weaver/codecs/CodecsTest.scala
@@ -49,7 +49,7 @@ object CodecsTest extends SimpleIOSuite {
       outcomes.map(TestData.fromTestOutcome) ++
       List(SuiteEnds("foo"))
 
-  simpleTest(
+  test(
     "golden test: previously serialised payload is still deserialisable") {
     for {
       inputStream <- IO(getClass.getResourceAsStream("/golden.json"))

--- a/modules/core/src/weaver/suites.scala
+++ b/modules/core/src/weaver/suites.scala
@@ -49,8 +49,6 @@ trait EffectSuite[F[_]] extends Suite[F] with EffectSuiteAux with SourceLocation
   final def run(args : List[String])(report : TestOutcome => F[Unit]) : F[Unit] =
     spec(args).evalMap(report).compile.drain.adaptErr(adaptRunError)
 
-  implicit def expectationsConversion(e: Expectations): F[Expectations] =
-    effectCompat.effect.pure(e)
 }
 
 trait RunnableSuite[F[_]] extends EffectSuite[F] {
@@ -74,7 +72,6 @@ trait MutableFSuite[F[_]] extends EffectSuite[F]  {
     }
 
   def pureTest(name: TestName)(run : => Expectations) :  Unit = registerTest(name)(_ => Test(name.name, effectCompat.effect.delay(run)))
-  def simpleTest(name:  TestName)(run: => F[Expectations]) : Unit = registerTest(name)(_ => Test(name.name, effectCompat.effect.defer(run)))
   def loggedTest(name: TestName)(run: Log[F] => F[Expectations]) : Unit = registerTest(name)(_ => Test(name.name, log => run(log)))
   def test(name: TestName) : PartiallyAppliedTest = new PartiallyAppliedTest(name)
 

--- a/modules/framework/cats/test/src/Meta.scala
+++ b/modules/framework/cats/test/src/Meta.scala
@@ -20,19 +20,19 @@ object Meta {
       SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
-    simpleTest("lots\nof\nmultiline\n(success)") {
+    pureTest("lots\nof\nmultiline\n(success)") {
       expect(1 == 1)
     }
 
-    simpleTest("lots\nof\nmultiline\n(failure)") {
+    pureTest("lots\nof\nmultiline\n(failure)") {
       expect(1 == 2)
     }
 
-    simpleTest("lots\nof\nmultiline\n(ignored)") {
+    test("lots\nof\nmultiline\n(ignored)") {
       ignore("Ignore me")
     }
 
-    simpleTest("lots\nof\nmultiline\n(cancelled)") {
+    test("lots\nof\nmultiline\n(cancelled)") {
       cancel("I was cancelled :(")
     }
   }
@@ -42,15 +42,15 @@ object Meta {
       SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
-    simpleTest("I succeeded") {
+    pureTest("I succeeded") {
       success
     }
 
-    simpleTest("I failed") {
+    pureTest("I failed") {
       failure(":(")
     }
 
-    simpleTest("I succeeded again") {
+    pureTest("I succeeded again") {
       success
     }
   }

--- a/modules/framework/cats/test/src/MutableSuiteTest.scala
+++ b/modules/framework/cats/test/src/MutableSuiteTest.scala
@@ -6,11 +6,11 @@ import scala.concurrent.duration._
 
 abstract class MutableSuiteTest extends SimpleIOSuite {
 
-  test("23 is odd") {
+  pureTest("23 is odd") {
     expect(23 % 2 == 1)
   }
 
-  simpleTest("sleeping") {
+  test("sleeping") {
     for {
       before <- CatsUnsafeRun.realTimeMillis
       _      <- CatsUnsafeRun.sleep(1.seconds)
@@ -18,7 +18,7 @@ abstract class MutableSuiteTest extends SimpleIOSuite {
     } yield expect(after - before >= 1000)
   }
 
-  test("23 is odd") {
+  pureTest("23 is odd") {
     expect(23 % 2 == 1)
   }
 

--- a/modules/framework/cats/test/src/SourceLocationTest.scala
+++ b/modules/framework/cats/test/src/SourceLocationTest.scala
@@ -7,7 +7,7 @@ object SourceLocationTest extends SimpleIOSuite {
   // DO NOT MOVE THIS
   val sourceLocation = implicitly[SourceLocation]
 
-  test("implicit capture of source location is relativised") {
+  pureTest("implicit capture of source location is relativised") {
     val name    = sourceLocation.fileName
     val relPath = sourceLocation.fileRelativePath
     val line    = sourceLocation.line

--- a/modules/framework/cats/test/src/TracingTests.scala
+++ b/modules/framework/cats/test/src/TracingTests.scala
@@ -19,7 +19,7 @@ object TracingTests extends SimpleIOSuite {
 
   val thisFile = "/modules/framework/cats/test/src/TracingTests.scala"
 
-  test("Traces work as expected") {
+  pureTest("Traces work as expected") {
     val result = isOdd(2)
       .traced(here)
       .traced(here)

--- a/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
@@ -102,9 +102,9 @@ trait Checkers {
   /** ScalaCheck test parameters instance. */
   val numbers = fs2.Stream.iterate(1)(_ + 1)
 
-  def forall[A: Show](gen: Gen[A])(f: A => F[Expectations])(
+  def forall[A: Show, B: PropF](gen: Gen[A])(f: A => B)(
       implicit loc: SourceLocation): F[Expectations] =
-    Ref[F].of(Status.start[A]).flatMap(forall_(gen, f))
+    Ref[F].of(Status.start[A]).flatMap(forall_(gen, liftProp(f)))
 
   private def forall_[A: Show](gen: Gen[A], f: A => F[Expectations])(
       state: Ref[F, Status[A]])(

--- a/modules/scalacheck/test/src/weaver/scalacheck/CheckersTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/CheckersTest.scala
@@ -13,55 +13,55 @@ object CheckersTest extends SimpleIOSuite with Checkers {
   override def checkConfig: CheckConfig =
     super.checkConfig.copy(perPropertyParallelism = 100)
 
-  simpleTest("universal") {
+  test("universal") {
     forall(Gen.posNum[Int]) { a =>
       expect(a > 0)
     }
   }
 
-  simpleTest("form 1") {
+  test("form 1") {
     forall { (a: Int) =>
       expect(a * 2 == 2 * a)
     }
   }
 
-  simpleTest("form 2") {
+  test("form 2") {
     forall { (a1: Int, a2: Int) =>
       expect(a1 * a2 == a2 * a1)
     }
   }
 
-  simpleTest("form 3") {
+  test("form 3") {
     forall { (a1: Int, a2: Int, a3: Int) =>
       expect(a1 * a2 * a3 == a3 * a2 * a1)
     }
   }
 
-  simpleTest("form 4") {
+  test("form 4") {
     forall { (a1: Int, a2: Int, a3: Int, a4: Int) =>
       expect(a1 * a2 * a3 * a4 == a4 * a3 * a2 * a1)
     }
   }
 
-  simpleTest("form 5") {
+  test("form 5") {
     forall { (a1: Int, a2: Int, a3: Int, a4: Int, a5: Int) =>
       expect(a1 * a2 * a3 * a4 * a5 == a5 * a4 * a3 * a2 * a1)
     }
   }
 
-  simpleTest("form 6") {
+  test("form 6") {
     forall { (a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int) =>
       expect(a1 * a2 * a3 * a4 * a5 * a6 == a6 * a5 * a4 * a3 * a2 * a1)
     }
   }
 
-  simpleTest("IO form (1)") {
+  test("IO form (1)") {
     forall { (a1: Int) =>
       IO.sleep(100.millis).map(_ => expect(a1 * 2 == a1 + a1))
     }
   }
 
-  simpleTest("IO form (2)") {
+  test("IO form (2)") {
     forall { (a1: Int, a2: Int) =>
       IO.sleep(1.second).map(_ => expect(a1 + a2 == a2 + a1))
     }

--- a/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -58,7 +58,7 @@ object Meta {
       super.checkConfig
         .copy(perPropertyParallelism = 100, minimumSuccessful = 100)
 
-    simpleTest("sleeping forall") {
+    test("sleeping forall") {
       forall { (x: Int, y: Int) =>
         IO.sleep(1.second) *> IO(expect(x + y == y + x))
       }
@@ -70,7 +70,7 @@ object Meta {
     override def checkConfig: CheckConfig =
       super.checkConfig.copy(perPropertyParallelism = 1, initialSeed = Some(5L))
 
-    simpleTest("foobar") {
+    test("foobar") {
       forall { (x: Int) =>
         expect(x > 0)
       }

--- a/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
+++ b/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
@@ -32,42 +32,42 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
     )
   }
 
-  pureTest("simpleTest { expectFailure { 1 must beEqualTo(2) } }") {
+  pureTest("pureTest { expectFailure { 1 must beEqualTo(2) } }") {
     expectFailure { 1 must beEqualTo(2) }
   }
 
-  pureTest("simpleTest { expectFailure { 1 must be_==(2) } }") {
+  pureTest("pureTest { expectFailure { 1 must be_==(2) } }") {
     expectFailure(1 must be_==(2))
   }
 
-  pureTest("simpleTest { expectFailure { 1 must_== 2 } }") {
+  pureTest("pureTest { expectFailure { 1 must_== 2 } }") {
     expectFailure(1 must_== 2)
   }
 
-  pureTest("simpleTest { expectFailure { 1 mustEqual 2 } }") {
+  pureTest("pureTest { expectFailure { 1 mustEqual 2 } }") {
     expectFailure { 1 mustEqual 2 }
   }
 
-  pureTest("simpleTest { expectFailure { 1 === 2 failed } }") {
+  pureTest("pureTest { expectFailure { 1 === 2 failed } }") {
     expectFailure(1 === 2)
   }
-  simpleTest("simpleTest { 1 must beEqualTo(1) }") {
+  pureTest("pureTest { 1 must beEqualTo(1) }") {
     1 must beEqualTo(1)
   }
 
-  simpleTest("simpleTest { 1 must be_==(1) }") {
+  pureTest("pureTest { 1 must be_==(1) }") {
     1 must be_==(1)
   }
 
-  simpleTest("simpleTest { 1 must_== 1 }") {
+  pureTest("pureTest { 1 must_== 1 }") {
     1 must_== 1
   }
 
-  simpleTest("simpleTest { 1 mustEqual 1 }") {
+  pureTest("pureTest { 1 mustEqual 1 }") {
     1 mustEqual 1
   }
 
-  simpleTest("simpleTest { 1 === 1 }") {
+  pureTest("pureTest { 1 === 1 }") {
     1 === 1
   }
 }


### PR DESCRIPTION
Because this leads to the confusion that expectations can be used within for-comprehensions without any method call, which doesn't have any effect, which violates principle of least surprise.

Also removes `simpleTest` as it overlaps with one of the `test` overloads 