### PR TITLE
Add scalatest interop module

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ libraryDependencies +=  "com.disneystreaming" %% "weaver-scalacheck" % "x.y.z" %
 // optionally (for specs2 interop)
 libraryDependencies +=  "com.disneystreaming" %% "weaver-specs2" % "x.y.z" % Test
 
+// optionally (for scalatest interop)
+libraryDependencies +=  "com.disneystreaming" %% "weaver-scalatest" % "x.y.z" % Test
 ```
 
 ## Motivation

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ lazy val allModules = Seq(
   framework.projectRefs,
   scalacheck.projectRefs,
   specs2.projectRefs,
+  scalatest.projectRefs,
   intellijRunner.projectRefs,
   effectCores,
   effectFrameworks
@@ -106,7 +107,8 @@ val allEffectCoresFilter: ScopeFilter =
 
 val allIntegrationsCoresFilter: ScopeFilter =
   ScopeFilter(
-    inProjects((scalacheck.projectRefs ++ specs2.projectRefs): _*),
+    inProjects(
+      (scalacheck.projectRefs ++ specs2.projectRefs ++ scalatest.projectRefs): _*),
     inConfigurations(Compile)
   )
 
@@ -114,7 +116,7 @@ lazy val docs = projectMatrix
   .in(file("modules/docs"))
   .jvmPlatform(WeaverPlugin.supportedScala2Versions)
   .enablePlugins(DocusaurusPlugin, MdocPlugin)
-  .dependsOn(core, scalacheck, cats, zio, monix, monixBio, specs2)
+  .dependsOn(core, scalacheck, cats, zio, monix, monixBio, specs2, scalatest)
   .settings(
     moduleName := "docs",
     watchSources += (ThisBuild / baseDirectory).value / "docs",
@@ -233,6 +235,21 @@ lazy val specs2 = projectMatrix
     testFrameworks := Seq(new TestFramework("weaver.framework.CatsEffect")),
     libraryDependencies ++= Seq(
       "org.specs2" %%% "specs2-matcher" % "4.10.6"
+    )
+  )
+  .settings(WeaverPlugin.simpleLayout)
+
+lazy val scalatest = projectMatrix
+  .in(file("modules/scalatest"))
+  .sparse(withCE3 = true, withJS = true, withScala3 = false)
+  .dependsOn(core, cats % "test->compile")
+  .configure(WeaverPlugin.profile)
+  .settings(
+    name := "scalatest",
+    testFrameworks := Seq(new TestFramework("weaver.framework.CatsEffect")),
+    libraryDependencies ++= Seq(
+      "org.scalatest" %%% "scalatest-shouldmatchers" % "3.2.5",
+      "org.scalatest" %%% "scalatest-mustmatchers"   % "3.2.5"
     )
   )
   .settings(WeaverPlugin.simpleLayout)

--- a/docs/scalatest.md
+++ b/docs/scalatest.md
@@ -1,0 +1,57 @@
+---
+id: scalatest
+title: scalatest integration
+---
+
+Weaver comes with [scalatest](http://scalatest.org/) matchers interop, allowing for matcher style testing.
+
+## Installation
+
+You'll need to install an additional dependency in order to use scalatest matchers with Weaver.
+
+### SBT
+```scala
+libraryDependencies +=  "com.disneystreaming" %% "weaver-scalatest" % "@VERSION@" % Test
+```
+
+### Mill
+```scala
+object test extends Tests {
+  def ivyDeps = Agg(
+    ivy"com.disneystreaming::weaver-scalatest:@VERSION@"
+  )
+}
+```
+
+## Usage
+
+Add the `weaver.scalatestcompat.IOShouldMatchers` or `weaver.scalatestcompat.IOMustMatchers` mixins to use scalatest matchers within your test suite.
+
+```scala mdoc
+import weaver.SimpleIOSuite
+
+import weaver.scalatest.IOMustMatchers
+
+object MustMatchersSpec extends SimpleIOSuite with IOMustMatchers {
+  pureTest("pureTest { 1 mustBe 1 }") {
+    1 mustBe 1
+  }
+
+  pureTest("pureTest { 1 must be (1) }") {
+    1 must be (1)
+  }
+
+
+  pureTest("pureTest { 1 mustEqual 1 }") {
+    1 mustEqual 1
+  }
+
+  pureTest("pureTest { 1 must equal (1) }") {
+    1 must equal (1)
+  }
+
+  pureTest("pureTest { 1 must === (1) }") {
+    1 must === (1)
+  }
+}
+```

--- a/modules/docs/src/main/scala/weaver/MatrixRendering.scala
+++ b/modules/docs/src/main/scala/weaver/MatrixRendering.scala
@@ -82,6 +82,7 @@ object Table {
     case "monix-bio"  => "Monix BIO"
     case "scalacheck" => "ScalaCheck"
     case "specs2"     => "Specs2 matchers"
+    case "scalatest"     => "Scalatest matchers"
     case _            => throw new RuntimeException("Not another effect type!")
   }
 

--- a/modules/scalatest/src/weaver/scalatestcompat/Matchers.scala
+++ b/modules/scalatest/src/weaver/scalatestcompat/Matchers.scala
@@ -1,0 +1,27 @@
+package weaver.scalatestcompat
+
+import cats.Monoid
+import weaver.{ EffectSuite, Expectations, SourceLocation }
+import weaver.Expectations.Helpers._
+import org.scalatest.Assertion
+import scala.util.{ Failure, Success, Try }
+
+trait Matchers[F[_]] {
+  self: EffectSuite[F] =>
+
+  implicit def toExpectations(
+      a: Assertion
+  )(
+      implicit pos: SourceLocation
+  ): Expectations =
+    Try(a) match {
+      case Success(_) => Monoid[Expectations].empty
+      case Failure(t) => failure(t.getMessage)
+    }
+
+  implicit def toExpectationsF(
+      a: Assertion
+  )(
+      implicit pos: SourceLocation
+  ): F[Expectations] = effectCompat.effect.pure(toExpectations(a))
+}

--- a/modules/scalatest/src/weaver/scalatestcompat/MustMatchers.scala
+++ b/modules/scalatest/src/weaver/scalatestcompat/MustMatchers.scala
@@ -1,0 +1,13 @@
+package weaver.scalatestcompat
+
+import cats.effect.IO
+import org.scalatest.matchers.must
+import weaver.EffectSuite
+
+trait MustMatchers[F[_]] extends Matchers[F] with must.Matchers {
+  self: EffectSuite[F] =>
+}
+
+trait IOMustMatchers extends MustMatchers[IO] {
+  self: EffectSuite[IO] =>
+}

--- a/modules/scalatest/src/weaver/scalatestcompat/ShouldMatchers.scala
+++ b/modules/scalatest/src/weaver/scalatestcompat/ShouldMatchers.scala
@@ -1,0 +1,13 @@
+package weaver.scalatestcompat
+
+import cats.effect.IO
+import org.scalatest.matchers.should
+import weaver.EffectSuite
+
+trait ShouldMatchers[F[_]] extends Matchers[F] with should.Matchers {
+  self: EffectSuite[F] =>
+}
+
+trait IOShouldMatchers extends ShouldMatchers[IO] {
+  self: EffectSuite[IO] =>
+}

--- a/modules/scalatest/test/src/weaver/scalatestcompat/MustMatchersSpec.scala
+++ b/modules/scalatest/test/src/weaver/scalatestcompat/MustMatchersSpec.scala
@@ -1,0 +1,45 @@
+package weaver.scalatestcompat
+
+import weaver.SimpleIOSuite
+
+object MustMatchersSpec extends SimpleIOSuite with IOMustMatchers {
+  pureTest("pureTest { 1 mustBe 1 }") {
+    1 mustBe 1
+  }
+
+  pureTest("pureTest { 1 must be (1) }") {
+    1 must be(1)
+  }
+
+  pureTest("pureTest { 1 mustEqual 1 }") {
+    1 mustEqual 1
+  }
+
+  pureTest("pureTest { 1 must equal (1) }") {
+    1 must equal(1)
+  }
+
+  pureTest("pureTest { 1 must === (1) }") {
+    1 must ===(1)
+  }
+
+  pureTest("pureTest { expectFailure { 1 mustBe 2 } }") {
+    expectFailure { 1 mustBe 2 }
+  }
+
+  pureTest("pureTest { expectFailure { 1 must be (2) } }") {
+    expectFailure { 1 must be(2) }
+  }
+
+  pureTest("pureTest { expectFailure { 1 mustEqual 2 } }") {
+    expectFailure { 1 mustEqual 2 }
+  }
+
+  pureTest("pureTest { expectFailure { 1 must equal (2) } }") {
+    expectFailure { 1 must equal(2) }
+  }
+
+  pureTest("pureTest { expectFailure { 1 must === (2) } }") {
+    expectFailure { 1 must ===(2) }
+  }
+}

--- a/modules/scalatest/test/src/weaver/scalatestcompat/ShouldMatchersSpec.scala
+++ b/modules/scalatest/test/src/weaver/scalatestcompat/ShouldMatchersSpec.scala
@@ -1,0 +1,45 @@
+package weaver.scalatestcompat
+
+import weaver.SimpleIOSuite
+
+object ShouldMatchersSpec extends SimpleIOSuite with IOShouldMatchers {
+  pureTest("pureTest { 1 shouldBe 1 }") {
+    1 shouldBe 1
+  }
+
+  pureTest("pureTest { 1 should be (1) }") {
+    1 should be(1)
+  }
+
+  pureTest("pureTest { 1 shouldEqual 1 }") {
+    1 shouldEqual 1
+  }
+
+  pureTest("pureTest { 1 should equal (1) }") {
+    1 should equal(1)
+  }
+
+  pureTest("pureTest { 1 should === (1) }") {
+    1 should ===(1)
+  }
+
+  pureTest("pureTest { expectFailure { 1 shouldBe 2 } }") {
+    expectFailure { 1 shouldBe 2 }
+  }
+
+  pureTest("pureTest { expectFailure {1 should be (2) } }") {
+    expectFailure { 1 should be(2) }
+  }
+
+  pureTest("pureTest { expectFailure { 1 shouldEqual 2 } }") {
+    expectFailure { 1 shouldEqual 2 }
+  }
+
+  pureTest("pureTest { expectFailure { 1 should equal (2) } }") {
+    expectFailure { 1 should equal(2) }
+  }
+
+  pureTest("pureTest { expectFailure { 1 should === (2) } }") {
+    expectFailure { 1 should ===(2) }
+  }
+}

--- a/modules/scalatest/test/src/weaver/scalatestcompat/package.scala
+++ b/modules/scalatest/test/src/weaver/scalatestcompat/package.scala
@@ -1,0 +1,15 @@
+package weaver
+
+import org.scalatest.Assertion
+import org.scalatest.exceptions.TestFailedException
+import scala.util.Try
+import Expectations.Helpers._
+
+package object scalatestcompat {
+  def expectFailure(assertion: => Assertion): Expectations = {
+    Try(assertion).fold(
+      t => expect(t.isInstanceOf[TestFailedException]),
+      _ => failure("Expected assertion exception")
+    )
+  }
+}

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -18,6 +18,7 @@
       "tagging",
       "scalacheck",
       "specs2",
+      "scalatest",
       "parallelism"
     ],
     "Sample reports": [


### PR DESCRIPTION
A scalatest interop module with scalatest's [must](https://www.scalatest.org/scaladoc/3.2.5/org/scalatest/matchers/must/index.html) and [should](https://www.scalatest.org/scaladoc/3.2.5/org/scalatest/matchers/should/index.html) matchers.
