### PR TITLE
Re-do the FunSuite hierarchy

### DIFF
--- a/docs/intellij.md
+++ b/docs/intellij.md
@@ -27,15 +27,15 @@ A `.only` extension method is provided on strings, and can be used when declarin
 
 ```scala mdoc  
 import weaver._
-import cats.effect.
+import cats.effect._
 
 object MySuite extends SimpleIOSuite {
 
-  test("test this".only){
-    IO(succeed)
+  test("test this") {
+    IO(success)
   }
 
-  test("do not test this"){
+  test("do not test this") {
     IO.raiseError(new Throwable("Boom"))
   }
 

--- a/modules/core/cats/src-ce2/weaver/BaseIOSuites.scala
+++ b/modules/core/cats/src-ce2/weaver/BaseIOSuites.scala
@@ -10,7 +10,7 @@ trait BaseIOSuite extends BaseCatsSuite { self: RunnableSuite[IO] =>
   final implicit protected def timer: Timer[IO] = effectCompat.timer
 }
 
-trait BaseFunIOSuite extends FunSuiteAux[IO] with BaseCatsSuite {
+trait BaseFunIOSuite extends FunSuiteF[IO] with BaseCatsSuite {
   override implicit protected def effectCompat: UnsafeRun[EffectType] =
     CatsUnsafeRun
 }

--- a/modules/core/cats/src-ce3/weaver/BaseIOSuite.scala
+++ b/modules/core/cats/src-ce3/weaver/BaseIOSuite.scala
@@ -6,6 +6,6 @@ trait BaseIOSuite extends RunnableSuite[IO] with BaseCatsSuite {
   implicit protected def effectCompat: UnsafeRun[IO] = CatsUnsafeRun
 }
 
-trait BaseFunIOSuite extends FunSuiteAux[IO] with BaseCatsSuite {
+trait BaseFunIOSuite extends FunSuiteF[IO] with BaseCatsSuite {
   implicit protected def effectCompat: UnsafeRun[EffectType] = CatsUnsafeRun
 }

--- a/modules/core/monix/src/weaver/monixcompat/suites.scala
+++ b/modules/core/monix/src/weaver/monixcompat/suites.scala
@@ -39,7 +39,7 @@ trait SimpleMutableTaskSuite extends MutableTaskSuite {
 }
 
 trait FunTaskSuite
-    extends FunSuiteAux[Task]
+    extends FunSuiteF[Task]
     with BaseTaskSuite
     with Expectations.Helpers {
   implicit protected def effectCompat = MonixUnsafeRun

--- a/modules/core/monixBio/src/weaver/monixbiocompat/suites.scala
+++ b/modules/core/monixBio/src/weaver/monixbiocompat/suites.scala
@@ -65,7 +65,7 @@ abstract class SimpleMutableIOSuite extends MutableIOSuite {
 }
 
 trait FunIOSuite
-    extends FunSuiteAux[Task]
+    extends FunSuiteF[Task]
     with BaseIOSuite
     with Expectations.Helpers {
   implicit protected def effectCompat               = MonixBIOUnsafeRun

--- a/modules/core/src/weaver/suites.scala
+++ b/modules/core/src/weaver/suites.scala
@@ -117,8 +117,12 @@ abstract class MutableFSuite[F[_]] extends RunnableSuite[F]  {
 
 }
 
-abstract class FunSuiteAux[F[_]] extends RunnableSuite[F] { self =>
-  def test(name: TestName)(run: => Expectations): Unit = synchronized {
+trait FunSuiteAux {
+  def test(name: TestName)(run: => Expectations): Unit
+}
+
+abstract class FunSuiteF[F[_]] extends RunnableSuite[F] with FunSuiteAux { self =>
+  override def test(name: TestName)(run: => Expectations): Unit = synchronized {
     if(isInitialized) throw initError
     testSeq = testSeq :+ (name -> (() => Test.pure(name.name)(() => run)))
   }

--- a/modules/core/zio/src/weaver/ziocompat/suites.scala
+++ b/modules/core/zio/src/weaver/ziocompat/suites.scala
@@ -85,7 +85,7 @@ abstract class SimpleMutableZIOSuite extends MutableZIOSuite[Has[Unit]] {
 }
 
 trait FunZIOSuite
-    extends FunSuiteAux[T]
+    extends FunSuiteF[T]
     with BaseZIOSuite
     with Expectations.Helpers {
   override implicit protected def effectCompat = ZIOUnsafeRun


### PR DESCRIPTION
This is to allow integration similar to `EffectSuiteAux`. 

A hypothetical Discipline integration will look like this:

```scala
package weaver.myintegration

import weaver.Expectations.Helpers._

// integration
trait Discipline { self: weaver.FunSuiteAux => 
  for(i <- 1 to 10) test("howdy") {success}
}

// usages
object TaskDiscipline extends weaver.monixcompat.FunSuite with Discipline
object ZioDiscipline extends weaver.ziocompat.FunSuite with Discipline
object CatsDiscipline extends weaver.FunSuite with Discipline
object MonixBioDiscipline extends weaver.monixbiocompat.FunSuite with Discipline

object Main extends App {
  ZioDiscipline.runUnsafe(Nil)(println)
}

```