### PR TITLE
Adds `expect.eql`, a stricter version of `expect.same`

### DIFF
--- a/modules/core/src/weaver/internals/ExpectSame.scala
+++ b/modules/core/src/weaver/internals/ExpectSame.scala
@@ -9,10 +9,10 @@ import com.eed3si9n.expecty._
 
 private[weaver] trait ExpectSame {
 
-  def same[A](
+  def eql[A](
       expected: A,
       found: A)(
-      implicit eqA: Eq[A] = Eq.fromUniversalEquals[A],
+      implicit eqA: Eq[A],
       showA: Show[A] = Show.fromToString[A],
       loc: SourceLocation): Expectations = {
 
@@ -36,4 +36,14 @@ private[weaver] trait ExpectSame {
           new AssertionException(header + "\n\n" + diff, sourceLocs)))
     }
   }
+
+  /**
+   * Same as eql but defaults to universal equality.
+   */
+  def same[A](
+      expected: A,
+      found: A)(
+      implicit eqA: Eq[A] = Eq.fromUniversalEquals[A],
+      showA: Show[A] = Show.fromToString[A],
+      loc: SourceLocation): Expectations = eql(expected, found)
 }


### PR DESCRIPTION
Fixes https://github.com/disneystreaming/weaver-test/issues/260

Cannot test the difference with `same` until we have https://github.com/disneystreaming/weaver-test/issues/261