### PR TITLE
Use built-in Scala.js APIs for formatting timestamps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,10 @@ ThisBuild / commands += Command.command("ci") { state =>
   "versionDump" ::
     "scalafmtCheckAll" ::
     "scalafix --check" ::
-    "test:scalafix --check" ::
+    "Test/scalafix --check" ::
     "clean" ::
-    "test:compile" ::
-    "test:fastLinkJS" :: // do this separately as it's memory intensive
+    "Test/compile" ::
+    "Test/fastLinkJS" :: // do this separately as it's memory intensive
     "test" ::
     "docs/docusaurusCreateSite" ::
     "core/publishLocal" :: state
@@ -15,7 +15,7 @@ ThisBuild / commands += Command.command("ci") { state =>
 
 ThisBuild / commands += Command.command("fix") { state =>
   "scalafix" ::
-    "test:scalafix" ::
+    "Test/scalafix" ::
     "scalafmtAll" ::
     "scalafmtSbt" :: state
 }
@@ -88,11 +88,7 @@ lazy val core = projectMatrix
           "org.scala-js" %%% "scalajs-stubs" % "1.0.0"  % "provided" cross CrossVersion.for3Use2_13,
           "junit"          % "junit"         % "4.13.2" % Optional
         )
-      else {
-        Seq(
-          "io.github.cquiroz" %%% "scala-java-time" % "2.2.1"
-        )
-      }
+      else Seq.empty
     },
     libraryDependencies ++= {
       if (virtualAxes.value.contains(VirtualAxis.jvm)) {
@@ -212,8 +208,7 @@ lazy val framework = projectMatrix
         )
       else
         Seq(
-          "org.scala-js"       %% "scalajs-test-interface" % scalaJSVersion cross CrossVersion.for3Use2_13,
-          "io.github.cquiroz" %%% "scala-java-time-tzdb"   % "2.2.1" % Test
+          "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion cross CrossVersion.for3Use2_13
         )
     } ++ Seq("junit" % "junit" % "4.13.2")
   )
@@ -335,10 +330,7 @@ lazy val cats = projectMatrix
   .settings(WeaverPlugin.simpleLayout)
   .settings(
     name := "cats",
-    testFrameworks := Seq(new TestFramework("weaver.framework.CatsEffect")),
-    libraryDependencies += {
-      "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.2.1" % Test
-    }
+    testFrameworks := Seq(new TestFramework("weaver.framework.CatsEffect"))
   )
 
 lazy val monix = projectMatrix

--- a/build.sbt
+++ b/build.sbt
@@ -363,7 +363,8 @@ lazy val zio = projectMatrix
   .settings(WeaverPlugin.simpleLayout)
   .settings(
     name := "zio",
-    testFrameworks := Seq(new TestFramework("weaver.framework.ZIO"))
+    testFrameworks := Seq(new TestFramework("weaver.framework.ZIO")),
+    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.2.1" % Test
   )
 
 // #################################################################################################

--- a/modules/core/src-js/weaver/internals/Timestamp.scala
+++ b/modules/core/src-js/weaver/internals/Timestamp.scala
@@ -1,0 +1,31 @@
+package weaver.internals
+
+import scalajs.js.Date
+
+private[weaver] object Timestamp {
+
+  def format(l: Long): String = {
+    val date = new Date(0)
+
+    date.setMilliseconds(l.toDouble)
+
+    val hour    = date.getHours()
+    val minutes = date.getMinutes()
+    val seconds = date.getSeconds()
+
+    s"$hour:$minutes:$seconds"
+  }
+
+  def now(): Long = Date.now().toLong
+
+  def localTime(hours: Int, minutes: Int, seconds: Int): Long = {
+    val date = new Date(Date.now())
+
+    date.setHours(hours.toDouble,
+                  min = minutes.toDouble,
+                  sec = seconds.toDouble)
+
+    date.getTime().toLong
+  }
+
+}

--- a/modules/core/src-jvm/weaver/internals/Timestamp.scala
+++ b/modules/core/src-jvm/weaver/internals/Timestamp.scala
@@ -1,0 +1,23 @@
+package weaver.internals
+
+import java.time.format.DateTimeFormatter
+import java.time.{ Instant, OffsetDateTime, ZoneId }
+
+private[weaver] object Timestamp {
+
+  def format(l: Long): String = {
+    val current =
+      OffsetDateTime.ofInstant(Instant.ofEpochMilli(l), ZoneId.systemDefault())
+
+    current.withNano(0).format(DateTimeFormatter.ISO_LOCAL_TIME)
+  }
+
+  def localTime(hours: Int, minutes: Int, seconds: Int): Long = {
+    java.time.OffsetDateTime.now
+      .withHour(hours)
+      .withMinute(minutes)
+      .withSecond(seconds)
+      .toEpochSecond * 1000
+
+  }
+}

--- a/modules/core/src/weaver/LogFormatter.scala
+++ b/modules/core/src/weaver/LogFormatter.scala
@@ -1,15 +1,5 @@
 package weaver
 
-import java.time.format.DateTimeFormatter
-import java.time.{ Instant, ZoneId }
-
 object LogFormatter {
-  def formatTimestamp(l: Long): String = {
-    Instant
-      .ofEpochMilli(l)
-      .atZone(ZoneId.systemDefault())
-      .toLocalTime
-      .withNano(0)
-      .format(DateTimeFormatter.ISO_LOCAL_TIME)
-  }
+  def formatTimestamp(l: Long): String = internals.Timestamp.format(l)
 }

--- a/modules/framework/cats/test/src/Meta.scala
+++ b/modules/framework/cats/test/src/Meta.scala
@@ -148,11 +148,7 @@ object Meta {
   }
 
   object SetTimeUnsafeRun extends CatsUnsafeRun {
-    private val setTimestamp = java.time.OffsetDateTime.now
-      .withHour(12)
-      .withMinute(54)
-      .withSecond(35)
-      .toEpochSecond * 1000
+    private val setTimestamp = weaver.internals.Timestamp.localTime(12, 54, 35)
 
     override def realTimeMillis: IO[Long] = IO.pure(setTimestamp)
   }

--- a/project/WeaverPlugin.scala
+++ b/project/WeaverPlugin.scala
@@ -462,6 +462,7 @@ object WeaverPlugin extends AutoPlugin {
     val desiredCommands: Map[String, (String, Triplet => Boolean)] = Map(
       "test"            -> ("test", any),
       "compile"         -> ("compile", any),
+      "publishLocal"    -> ("publishLocal", any),
       "pushRemoteCache" -> ("pushRemoteCache", any),
       "scalafix"        -> ("scalafix --check", jvm2_13),
       "scalafixTests"   -> ("Test/scalafix --check", jvm2_13),


### PR DESCRIPTION
Closes #263 

I removed the tzdb dependency as well, because that's what let this problem slip through.