### PR TITLE
specs2 integration - Fix "using `and` on `beSome`'s `ValueCheck` leads to failure"

### DIFF
--- a/modules/specs2/src/weaver/specs2compat/Matchers.scala
+++ b/modules/specs2/src/weaver/specs2compat/Matchers.scala
@@ -7,8 +7,8 @@ import cats.effect.IO
 
 import weaver.{ AssertionException, EffectSuite, Expectations, SourceLocation }
 
-import org.specs2.execute.{Failure, Result, Success}
-import org.specs2.matcher.{MatchResult, MustMatchers, StandardMatchResults}
+import org.specs2.execute.{ Failure, Result, Success }
+import org.specs2.matcher.{ MatchResult, MustMatchers, StandardMatchResults }
 
 trait Matchers[F[_]] extends MustMatchers {
   self: EffectSuite[F] =>
@@ -31,6 +31,10 @@ trait Matchers[F[_]] extends MustMatchers {
   )(
       implicit pos: SourceLocation
   ): F[Expectations] = effectCompat.effect.pure(toExpectations(m))
+
+  /** 
+   * Some specs2 matchers expect a MatchResult/Result so we might have to convert them back from weaver's Expectations
+   **/
 
   implicit def toSpecs2Result(ex: Expectations): Result =
     ex.run match {

--- a/modules/specs2/src/weaver/specs2compat/Matchers.scala
+++ b/modules/specs2/src/weaver/specs2compat/Matchers.scala
@@ -1,14 +1,14 @@
 package weaver.specs2compat
 
 import cats.Monoid
-import cats.data.Validated.{Invalid, Valid}
+import cats.data.Validated.{ Invalid, Valid }
 import cats.data.{ NonEmptyList, Validated }
 import cats.effect.IO
 
 import weaver.{ AssertionException, EffectSuite, Expectations, SourceLocation }
 
-import org.specs2.execute.{Failure, Success}
-import org.specs2.matcher.{MatchResult, MustMatchers, ValueCheck}
+import org.specs2.execute.{ Failure, Success }
+import org.specs2.matcher.{ MatchResult, MustMatchers, ValueCheck }
 
 trait Matchers[F[_]] extends MustMatchers {
   self: EffectSuite[F] =>
@@ -33,13 +33,16 @@ trait Matchers[F[_]] extends MustMatchers {
   ): F[Expectations] = effectCompat.effect.pure(toExpectations(m))
 
   implicit def toValueCheck[T](
-    ex: T => Expectations
-  ): ValueCheck[T] = ex.andThen(e => e.run match {
-    case Valid(_) => 
-      Success("", "")
-    case Invalid(err) =>
-      Failure(err.head.message, err.head.message, err.head.getStackTrace().toList)
-  })
+      check: T => Expectations
+  ): ValueCheck[T] = check.andThen(ex =>
+    ex.run match {
+      case Valid(_) =>
+        Success("", "")
+      case Invalid(err) =>
+        Failure(err.head.message,
+                err.head.message,
+                err.head.getStackTrace().toList)
+    })
 }
 
 trait IOMatchers extends Matchers[IO] {

--- a/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
+++ b/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
@@ -25,6 +25,22 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
     1 === 1
   }
 
+  pureTest("pureTest { (1 === 1) and (1 === 1) }") {
+    (1 === 1) and (1 === 1)
+  }
+
+  pureTest("pureTest { Some(1) must beSome(1) }") {
+    Some(1) must beSome(1)
+  }
+
+  pureTest("pureTest { Some(1) must beSome((i: Int) => i === 1) }") {
+    Some(1) must beSome((i: Int) => i === 1)
+  }
+
+  pureTest("pureTest { Some(1) must beSome((i: Int) => (i === 1) and (i === 1)) }") {
+    Some(1) must beSome((i: Int) => (i === 1) and (i === 1))
+  }
+
   def expectFailure[A](matchResult: MatchResult[A]): Expectations = {
     matchResult.run.toEither.fold(
       nel => expect(nel.head.message == matchResult.toResult.message),

--- a/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
+++ b/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
@@ -55,6 +55,15 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
     })
   }
 
+  pureTest("pureTest { 1 must beLike { case i: Int => i === 1 } }") {
+    1 must beLike { case i: Int => i === 1 }
+  }
+
+  pureTest(
+    "pureTest { 1 must beLike { case i: Int => (i === 1) and (i === 1) } }") {
+    1 must beLike { case i: Int => (i === 1) and (i === 1) }
+  }
+
   def expectFailure[A](matchResult: MatchResult[A]): Expectations = {
     matchResult.run.toEither.fold(
       nel => expect(nel.head.message == matchResult.toResult.message),

--- a/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
+++ b/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
@@ -41,11 +41,11 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
     Some(1) must beSome((i: Int) => i === 1)
   }
 
-  pureTest("pureTest { Some(1) must beSome((i: Int) => (i === 1) and (i === 1)) }") {
+  pureTest("deal with 'and' inside 'beSome' check") {
     Some(1) must beSome((i: Int) => (i === 1) and (i === 1))
   }
 
-  pureTest("pureTest { Some(1) must beSome((i: Int) => (i === 1) or (i === 1)) }") {
+  pureTest("deal with 'or' inside 'beSome' check") {
     Some(1) must beSome((i: Int) => (i === 1) or (i === 1))
   }
 
@@ -85,6 +85,6 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
   pureTest("pureTest { expectFailure { Some(1) must beSome((i: Int) => (i === 1) and (i === 2)) } }") {
     val matchResult = Some(1) must beSome((i: Int) => (i === 1) and (i === 2))
     expectFailure(matchResult) &&
-      expect(matchResult.message.contains("Some(1) is Some but 1 != 2"))
+    expect(matchResult.message.contains("Some(1) is Some but 1 != 2"))
   }
 }

--- a/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
+++ b/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
@@ -49,6 +49,12 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
     Some(1) must beSome((i: Int) => (i === 1) or (i === 1))
   }
 
+  pureTest("deal with nested beSome matchers") {
+    Some(1) must beSome((i: Int) => {
+      (i === 1) and (Some(1) must beSome((i: Int) => (i === 1) and (i === 1)))
+    })
+  }
+
   def expectFailure[A](matchResult: MatchResult[A]): Expectations = {
     matchResult.run.toEither.fold(
       nel => expect(nel.head.message == matchResult.toResult.message),
@@ -72,7 +78,13 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
     expectFailure { 1 mustEqual 2 }
   }
 
-  pureTest("pureTest { expectFailure { 1 === 2 failed } }") {
+  pureTest("pureTest { expectFailure { 1 === 2 } }") {
     expectFailure(1 === 2)
+  }
+
+  pureTest("pureTest { expectFailure { Some(1) must beSome((i: Int) => (i === 1) and (i === 2)) } }") {
+    val matchResult = Some(1) must beSome((i: Int) => (i === 1) and (i === 2))
+    expectFailure(matchResult) &&
+      expect(matchResult.message.contains("Some(1) is Some but 1 != 2"))
   }
 }

--- a/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
+++ b/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
@@ -29,6 +29,10 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
     (1 === 1) and (1 === 1)
   }
 
+  pureTest("pureTest { (1 === 1) or (1 === 1) }") {
+    (1 === 1) or (1 === 1)
+  }
+
   pureTest("pureTest { Some(1) must beSome(1) }") {
     Some(1) must beSome(1)
   }
@@ -39,6 +43,10 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
 
   pureTest("pureTest { Some(1) must beSome((i: Int) => (i === 1) and (i === 1)) }") {
     Some(1) must beSome((i: Int) => (i === 1) and (i === 1))
+  }
+
+  pureTest("pureTest { Some(1) must beSome((i: Int) => (i === 1) or (i === 1)) }") {
+    Some(1) must beSome((i: Int) => (i === 1) or (i === 1))
   }
 
   def expectFailure[A](matchResult: MatchResult[A]): Expectations = {

--- a/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
+++ b/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
@@ -51,23 +51,4 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
   pureTest("pureTest { expectFailure { 1 === 2 failed } }") {
     expectFailure(1 === 2)
   }
-  pureTest("pureTest { 1 must beEqualTo(1) }") {
-    1 must beEqualTo(1)
-  }
-
-  pureTest("pureTest { 1 must be_==(1) }") {
-    1 must be_==(1)
-  }
-
-  pureTest("pureTest { 1 must_== 1 }") {
-    1 must_== 1
-  }
-
-  pureTest("pureTest { 1 mustEqual 1 }") {
-    1 mustEqual 1
-  }
-
-  pureTest("pureTest { 1 === 1 }") {
-    1 === 1
-  }
 }

--- a/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
+++ b/modules/specs2/test/src/weaver/specs2compat/MatchersSpec.scala
@@ -59,8 +59,7 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
     1 must beLike { case i: Int => i === 1 }
   }
 
-  pureTest(
-    "pureTest { 1 must beLike { case i: Int => (i === 1) and (i === 1) } }") {
+  pureTest("pureTest { 1 must beLike { case i: Int => (i === 1) and (i === 1) } }") {
     1 must beLike { case i: Int => (i === 1) and (i === 1) }
   }
 
@@ -95,5 +94,15 @@ object MatchersSpec extends SimpleIOSuite with IOMatchers {
     val matchResult = Some(1) must beSome((i: Int) => (i === 1) and (i === 2))
     expectFailure(matchResult) &&
     expect(matchResult.message.contains("Some(1) is Some but 1 != 2"))
+  }
+
+  pureTest("pureTest { expectFailure { 1 must beLike { case i: Int => i === 2 } }") {
+    expectFailure(1 must beLike { case i: Int => i === 2 })
+  }
+
+  pureTest("pureTest { expectFailure { 1 must beLike { case i: Int => (i === 1) and (i === 2) } }") {
+    val matchResult = 1 must beLike { case i: Int => (i === 1) and (i === 2) }
+    expectFailure(matchResult) &&
+    expect(matchResult.message.contains("1 != 2"))
   }
 }


### PR DESCRIPTION
# Summary of changes
## Major
* See https://github.com/disneystreaming/weaver-test/issues/280. Some `specs2` matchers expect a `MatchResult`/`Result` so we might have to convert them back from weaver's `Expectations`. This PR adds implicits that deal with those conversions.

## Minor
* Remove duplicated tests