### PR TITLE
Keep result of any task in `UnsafeRun.sync`

### DIFF
--- a/modules/core/cats/src-ce2/weaver/CatsUnsafeRun.scala
+++ b/modules/core/cats/src-ce2/weaver/CatsUnsafeRun.scala
@@ -23,7 +23,7 @@ trait CatsUnsafeRun extends UnsafeRun[IO] {
 
   def cancel(token: CancelToken): Unit = sync(token)
 
-  def sync(task: IO[Unit]): Unit = task.unsafeRunSync()
+  def sync[A](task: IO[A]): A = task.unsafeRunSync()
 
   def async(task: IO[Unit]): Unit = task.unsafeRunAsyncAndForget()
 

--- a/modules/core/cats/src-ce3-js/weaver/CatsUnsafeRunPlatformCompat.scala
+++ b/modules/core/cats/src-ce3-js/weaver/CatsUnsafeRunPlatformCompat.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 private[weaver] trait CatsUnsafeRunPlatformCompat {
   self: CatsUnsafeRun =>
 
-  def sync(task: IO[Unit]): Unit = ???
+  def sync[A](task: IO[A]): A = throw new Exception("Cannot block on JS!")
 
   def background(task: IO[Unit]): CancelToken = ???
 

--- a/modules/core/cats/src-ce3-jvm/weaver/CatsUnsafeRunPlatformCompat.scala
+++ b/modules/core/cats/src-ce3-jvm/weaver/CatsUnsafeRunPlatformCompat.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.implicits.global
 
 private[weaver] trait CatsUnsafeRunPlatformCompat { self: CatsUnsafeRun =>
 
-  def sync(task: IO[Unit]): Unit = task.unsafeRunSync()
+  def sync[A](task: IO[A]): A = task.unsafeRunSync()
 
   def background(task: IO[Unit]): CancelToken =
     task.start.unsafeRunSync()

--- a/modules/core/monix/src-js/PlatformCompat.scala
+++ b/modules/core/monix/src-js/PlatformCompat.scala
@@ -4,8 +4,9 @@ package monixcompat
 import monix.execution.Scheduler
 
 object PlatformCompat {
-  def runSync(task: monix.eval.Task[Unit])(implicit scheduler: Scheduler) = {
+  def runSync[A](task: monix.eval.Task[A])(implicit scheduler: Scheduler) = {
     val _ = scheduler
+    throw new Exception("Cannot block on JS!")
   }
 
   def defaultScheduler: Scheduler = Scheduler.global

--- a/modules/core/monix/src-jvm/PlatformCompat.scala
+++ b/modules/core/monix/src-jvm/PlatformCompat.scala
@@ -4,7 +4,7 @@ package monixcompat
 import monix.execution.Scheduler
 
 object PlatformCompat {
-  def runSync(task: monix.eval.Task[Unit])(implicit scheduler: Scheduler) =
+  def runSync[A](task: monix.eval.Task[A])(implicit scheduler: Scheduler) =
     task.runSyncUnsafe()
 
   def defaultScheduler: Scheduler = Scheduler.fixedPool(

--- a/modules/core/monix/src/weaver/monixcompat/MonixUnsafeRun.scala
+++ b/modules/core/monix/src/weaver/monixcompat/MonixUnsafeRun.scala
@@ -25,7 +25,7 @@ object MonixUnsafeRun extends UnsafeRun[Task] {
 
   def cancel(token: CancelToken): Unit = token.cancel()
 
-  def sync(task: Task[Unit]): Unit = PlatformCompat.runSync(task)
+  def sync[A](task: Task[A]): A = PlatformCompat.runSync(task)
 
   def async(task: Task[Unit]): Unit = task.runAsyncAndForget
 

--- a/modules/core/monixBio/src-js/PlatformCompat.scala
+++ b/modules/core/monixBio/src-js/PlatformCompat.scala
@@ -4,8 +4,9 @@ package monixbiocompat
 import monix.execution.Scheduler
 
 object PlatformCompat {
-  def runSync(task: monix.bio.Task[Unit])(implicit scheduler: Scheduler) = {
+  def runSync[A](task: monix.bio.Task[A])(implicit scheduler: Scheduler) = {
     val _ = scheduler
+    throw new Exception("Cannot block on JS!")
   }
 
   def defaultScheduler: Scheduler = Scheduler.global

--- a/modules/core/monixBio/src-jvm/PlatformCompat.scala
+++ b/modules/core/monixBio/src-jvm/PlatformCompat.scala
@@ -4,7 +4,7 @@ package monixbiocompat
 import monix.execution.Scheduler
 
 object PlatformCompat {
-  def runSync(task: monix.bio.Task[Unit])(implicit scheduler: Scheduler) =
+  def runSync[A](task: monix.bio.Task[A])(implicit scheduler: Scheduler) =
     task.runSyncUnsafe()
 
   def defaultScheduler: Scheduler = Scheduler.fixedPool(

--- a/modules/core/monixBio/src/weaver/monixbiocompat/MonixBioUnsafeRun.scala
+++ b/modules/core/monixBio/src/weaver/monixbiocompat/MonixBioUnsafeRun.scala
@@ -19,7 +19,7 @@ object MonixBIOUnsafeRun extends UnsafeRun[monix.bio.Task] {
   def background(task: monix.bio.Task[Unit]): CancelToken = {
     task.runAsync { _ => () }(scheduler)
   }
-  def sync(task: monix.bio.Task[Unit]): Unit  = PlatformCompat.runSync(task)
+  def sync[A](task: monix.bio.Task[A]): A  = PlatformCompat.runSync(task)
   def async(task: monix.bio.Task[Unit]): Unit = task.runAsyncAndForget
   def cancel(token: CancelToken): Unit        = token.cancel()
 }

--- a/modules/core/src-ce2/weaver/UnsafeRun.scala
+++ b/modules/core/src-ce2/weaver/UnsafeRun.scala
@@ -34,7 +34,7 @@ trait UnsafeRun[F[_]] extends EffectCompat[F] {
   def background(task: F[Unit]): CancelToken
   def cancel(token: CancelToken): Unit
 
-  def sync(task: F[Unit]): Unit
+  def sync[A](task: F[A]): A
   def async(task: F[Unit]): Unit
 
 }

--- a/modules/core/src-ce3/weaver/UnsafeRun.scala
+++ b/modules/core/src-ce3/weaver/UnsafeRun.scala
@@ -37,7 +37,7 @@ trait UnsafeRun[F[_]] extends EffectCompat[F] {
   def background(task: F[Unit]): CancelToken
   def cancel(token: CancelToken): Unit
 
-  def sync(task: F[Unit]): Unit
+  def sync[A](task: F[A]): A
   def async(task: F[Unit]): Unit
 
 }

--- a/modules/core/zio/src-ce2/weaver/ziocompat/ZIOUnsafeRun.scala
+++ b/modules/core/zio/src-ce2/weaver/ziocompat/ZIOUnsafeRun.scala
@@ -27,7 +27,7 @@ object ZIOUnsafeRun extends UnsafeRun[T] {
   def cancel(token: Fiber.Id => Exit[Throwable, Unit]): Unit =
     discard[Exit[Throwable, Unit]](token(Fiber.Id.None))
 
-  def sync(task: T[Unit]): Unit = runtime.unsafeRun(task)
+  def sync[A](task: T[A]): A = runtime.unsafeRun(task)
 
   def async(task: T[Unit]): Unit = runtime.unsafeRunAsync(task)(_ => ())
 }

--- a/modules/core/zio/src-ce3/weaver/ziocompat/ZIOUnsafeRun.scala
+++ b/modules/core/zio/src-ce3/weaver/ziocompat/ZIOUnsafeRun.scala
@@ -23,7 +23,7 @@ object ZIOUnsafeRun extends UnsafeRun[T] {
   def cancel(token: Fiber.Id => Exit[Throwable, Unit]): Unit =
     discard[Exit[Throwable, Unit]](token(Fiber.Id.None))
 
-  def sync(task: T[Unit]): Unit = runtime.unsafeRun(task)
+  def sync[A](task: T[A]): A = runtime.unsafeRun(task)
 
   def async(task: T[Unit]): Unit = runtime.unsafeRunAsync(task)(_ => ())
 }


### PR DESCRIPTION
This should allow users to `unsafeRun` a task without providing an `IORuntime` themselves, e.g. if they want to add some customization layer between weaver and their tests.

I was hoping for binary compatibility, but `void` and `Object` probably don't play well...

Update: now I noticed weaver is using `global` 😅 what could go wrong...