### PR TITLE
Download all LFS images when building site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          lfs: true
 
       - uses: laughedelic/coursier-setup@v1
         with:


### PR DESCRIPTION
I *think* that's what the problem is with the site.

Default checkout strategy uses git LFS, and so the gh-pages branch is checked in with LFS pointers, instead of raw images: https://github.com/disneystreaming/weaver-test/blob/gh-pages/img/dss-white-transparent.svg