### PR TITLE
Misc docs improvements (test filtering, fix typos and spellings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,21 @@ If you want to build and run the website then you will need yarn installed:
 brew install yarn
 ```
 
+### Building the website
+
+If you're changing documentation, here's how you can check your changes locally:
+
+```bash
+sbt docs/docusaurusCreateSite
+cd website
+yarn start
+```
+
+If you're only changing `.md` files, you can run `sbt '~docs/mdoc'`.
+
+Note that the site will look a tiny bit different because to build a versioned website we have some machinery in the script running on CI - but you don't have to worry about that.
+
+
 ### IntelliJ plugin
 
 The code of the IntelliJ plugin lives [there](https://github.com/disneystreaming/weaver-intellij)

--- a/README.md
+++ b/README.md
@@ -251,9 +251,9 @@ If you want to build and run the website then you will need yarn installed:
 brew install yarn
 ```
 
-### Intellij plugin
+### IntelliJ plugin
 
-The code of the intellij plugin lives [there](https://github.com/disneystreaming/weaver-intellij)
+The code of the IntelliJ plugin lives [there](https://github.com/disneystreaming/weaver-intellij)
 
 ### PR Guidelines
 

--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ Something worth noting is that expectations are not throwing, and that if the us
 
 ### Filtering tests
 
-When using the IOSuite variants, the user can call the test command as such:
+When using the IOSuite variants, the user can call `sbt`'s test command as such:
 
 ``` 
-> test -- -o *foo*
+> testOnly -- -o *foo*
 ```
 
-This will filter prevent the execution of any test that doesn't contain the string "foo" in is qualified name. For a test labeled "foo" in a "FooSuite" object, in the package "fooPackage", the qualified name of a test is :
+This filter will prevent the execution of any test that doesn't contain the string "foo" in is qualified name. For a test labeled "foo" in a "FooSuite" object, in the package "fooPackage", the qualified name of a test is :
 
 ```
 fooPackage.FooSuite.foo

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ When using the IOSuite variants, the user can call `sbt`'s test command as such:
 > testOnly -- -o *foo*
 ```
 
-This filter will prevent the execution of any test that doesn't contain the string "foo" in is qualified name. For a test labeled "foo" in a "FooSuite" object, in the package "fooPackage", the qualified name of a test is :
+This filter will prevent the execution of any test that doesn't contain the string "foo" in is qualified name. For a test labeled "foo" in a "FooSuite" object, in the package "fooPackage", the qualified name of a test is:
 
 ```
 fooPackage.FooSuite.foo

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -1,0 +1,16 @@
+---
+id: filtering
+title: Filtering tests
+---
+
+When using the IOSuite variants, the user can call `sbt`'s test command as such:
+
+``` 
+> testOnly -- -o *foo*
+```
+
+This filter will prevent the execution of any test that doesn't contain the string "foo" in is qualified name. For a test labeled "foo" in a "FooSuite" object, in the package "fooPackage", the qualified name of a test is :
+
+```
+fooPackage.FooSuite.foo
+```

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -9,7 +9,7 @@ When using the IOSuite variants, the user can call `sbt`'s test command as such:
 > testOnly -- -o *foo*
 ```
 
-This filter will prevent the execution of any test that doesn't contain the string "foo" in is qualified name. For a test labeled "foo" in a "FooSuite" object, in the package "fooPackage", the qualified name of a test is :
+This filter will prevent the execution of any test that doesn't contain the string "foo" in is qualified name. For a test labeled "foo" in a "FooSuite" object, in the package "fooPackage", the qualified name of a test is:
 
 ```
 fooPackage.FooSuite.foo

--- a/docs/intellij.md
+++ b/docs/intellij.md
@@ -44,4 +44,4 @@ object MySuite extends SimpleIOSuite {
 
 ### Note regarding test durations
 
-Because of inherently modelling incompatiblities between weaver and IntelliJ, we had to implement the JUnit runner in a way that makes it impossible for durations to be reported correctly by the IDE. We apologise for the inconvenience.
+Because of inherently modelling incompatibilities between weaver and IntelliJ, we had to implement the JUnit runner in a way that makes it impossible for durations to be reported correctly by the IDE. We apologise for the inconvenience.

--- a/docs/intellij.md
+++ b/docs/intellij.md
@@ -1,11 +1,11 @@
 ---
 id: intellij
-title: intellij integration
+title: IntelliJ integration
 ---
 
-Starting with version 0.6.0, weaver provides intellij integration by means of a JUnit runner that Intellij picks up automatically.
+Starting with version 0.6.0, weaver provides IntelliJ integration by means of a JUnit runner that IntelliJ picks up automatically.
 
-## Note regarding the previous intellij integration
+## Note regarding the previous IntelliJ integration
 
 We (the maintainers) had tried to build an IntelliJ plugin. It worked but its maintenance became problematic quickly for us. We have made the decision to deprecate that plugin, sacrificing a little bit of UX in favour of an approach that is more compatible with our time constraints.
 
@@ -17,7 +17,7 @@ Nothing is needed (as long as weaver is declared correctly in your build).
 
 ### Running suites
 
-When test suites are open in Intellij, buttons appear to the left of the editor (next to the line number of the suite declaration), letting you run individual suites from the IDE.
+When test suites are open in IntelliJ, buttons appear to the left of the editor (next to the line number of the suite declaration), letting you run individual suites from the IDE.
 
 ![](../img/intellij_usage.png)
 
@@ -44,4 +44,4 @@ object MySuite extends SimpleIOSuite {
 
 ### Note regarding test durations
 
-Because of inherently modelling incompatiblities between weaver and Intellij, we had to implement the JUnit runner in a way that makes it impossible for durations to be reported correctly by the IDE. We apologise for the inconvenience.
+Because of inherently modelling incompatiblities between weaver and IntelliJ, we had to implement the JUnit runner in a way that makes it impossible for durations to be reported correctly by the IDE. We apologise for the inconvenience.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -20,7 +20,8 @@
       "specs2",
       "discipline",
       "parallelism",
-      "funsuite"
+      "funsuite",
+      "filtering"
     ],
     "Sample reports": [
       "multiple_suites_success",


### PR DESCRIPTION
## Summary
* Some improvements related with docs about filtering
* Fix misspelling of "IntelliJ"
* Fix https://github.com/disneystreaming/weaver-test/issues/288.

## Notes
* How should be decide if something is to be included in the README vs. the website? I added documentation regarding test filtering to the website, but now we have duplicate stuff between README and website...