### PR TITLE
ForEachTest resource

### DIFF
--- a/modules/core/cats/src/weaver/Suites.scala
+++ b/modules/core/cats/src/weaver/Suites.scala
@@ -23,6 +23,10 @@ abstract class MutableIOSuite
     with BaseIOSuite
     with Expectations.Helpers
 
+abstract class MutableForEachIOSuite extends MutableForEachSuite[IO]
+  with BaseIOSuite
+  with Expectations.Helpers
+
 abstract class SimpleMutableIOSuite extends MutableIOSuite {
   type Res = Unit
   def sharedResource: Resource[IO, Unit] = Resource.pure[IO, Unit](())

--- a/modules/core/cats/src/weaver/package.scala
+++ b/modules/core/cats/src/weaver/package.scala
@@ -3,6 +3,7 @@ import cats.effect.IO
 package object weaver {
 
   type IOSuite        = MutableIOSuite
+  type IOForEachSuite = MutableForEachIOSuite
   type SimpleIOSuite  = SimpleMutableIOSuite
   type GlobalResource = IOGlobalResource
   type GlobalRead     = GlobalResourceF.Read[IO]

--- a/modules/core/src/weaver/suites.scala
+++ b/modules/core/src/weaver/suites.scala
@@ -58,10 +58,9 @@ abstract class RunnableSuite[F[_]] extends EffectSuite[F] {
     effectCompat.sync(run(args)(outcome => effectCompat.effect.delay(report(outcome))))
 }
 
-abstract class MutableFSuite[F[_]] extends RunnableSuite[F]  {
+abstract class MutableBaseFSuite[F[_]] extends RunnableSuite[F]  {
 
   type Res
-  def sharedResource : Resource[F, Res]
 
   def maxParallelism : Int = 10000
 
@@ -81,26 +80,6 @@ abstract class MutableFSuite[F[_]] extends RunnableSuite[F]  {
     def apply(run : (Res, Log[F]) => F[Expectations]) : Unit = registerTest(name)(res => Test(name.name, log => run(res, log)))
   }
 
-  override def spec(args: List[String]) : Stream[F, TestOutcome] =
-    synchronized {
-      if (!isInitialized) isInitialized = true
-      val argsFilter = Filters.filterTests(this.name)(args)
-      val filteredTests = if (testSeq.exists(_._1.tags(TestName.Tags.only))){
-        testSeq.filter(_._1.tags(TestName.Tags.only)).map { case (_, test) => (res: Res) => test(res)}
-      } else testSeq.collect {
-        case (name, test) if argsFilter(name) => (res : Res) => test(res)
-      }
-      val parallism = math.max(1, maxParallelism)
-      if (filteredTests.isEmpty) Stream.empty // no need to allocate resources
-      else for {
-        resource <- Stream.resource(sharedResource)
-        tests = filteredTests.map(_.apply(resource))
-        testStream = Stream.emits(tests).lift[F](effectCompat.effect)
-        result <- if (parallism > 1 ) testStream.parEvalMap(parallism)(identity)(effectCompat.effect)
-                  else testStream.evalMap(identity)
-      } yield result
-    }
-
   private[this] var testSeq = Seq.empty[(TestName, Res => F[TestOutcome])]
 
   def plan: List[TestName] = testSeq.map(_._1).toList
@@ -112,6 +91,52 @@ abstract class MutableFSuite[F[_]] extends RunnableSuite[F]  {
       "Cannot define new tests after TestSuite was initialized"
     )
 
+
+  private[weaver] def getTests(args: List[String]) = {
+    if (!isInitialized) isInitialized = true
+    val argsFilter = Filters.filterTests(this.name)(args)
+    val filteredTests = if (testSeq.exists(_._1.tags(TestName.Tags.only))){
+      testSeq.filter(_._1.tags(TestName.Tags.only)).map { case (_, test) => (res: Res) => test(res)}
+    } else testSeq.collect {
+      case (name, test) if argsFilter(name) => (res : Res) => test(res)
+    }
+    val parallism = math.max(1, maxParallelism)
+
+    (filteredTests, parallism)
+  }
+}
+
+abstract class MutableFSuite[F[_]] extends MutableBaseFSuite[F]{
+  def sharedResource : Resource[F, Res]
+  override def spec(args: List[String]) : Stream[F, TestOutcome] =
+    synchronized {
+      val (filteredTests, parallism) = getTests(args)
+      if (filteredTests.isEmpty) Stream.empty // no need to allocate resources
+      else for {
+        resource <- Stream.resource(sharedResource)
+        tests = filteredTests.map(_.apply(resource))
+        testStream = Stream.emits(tests).lift[F](effectCompat.effect)
+        result <- if (parallism > 1 ) testStream.parEvalMap(parallism)(identity)(effectCompat.effect)
+        else testStream.evalMap(identity)
+      } yield result
+    }
+}
+abstract class MutableForEachSuite[F[_]] extends MutableBaseFSuite[F]{
+  def uniqueResource : Resource[F, Res]
+
+  override def spec(args: List[String]) : Stream[F, TestOutcome] =
+    synchronized {
+      val (filteredTests, parallism) = getTests(args)
+
+      if (filteredTests.isEmpty) Stream.empty // no need to allocate resources
+      else {
+        val testStream = Stream.emits(filteredTests).lift[F](effectCompat.effect)
+
+        if (parallism > 1 )
+          testStream.parEvalMap(parallism)(test => uniqueResource.use(test(_)))(effectCompat.effect)
+        else testStream.evalMap(test => uniqueResource.use(test(_)))
+      }
+    }
 }
 
 trait FunSuiteAux {

--- a/modules/framework/cats/test/src/Global.scala
+++ b/modules/framework/cats/test/src/Global.scala
@@ -2,13 +2,19 @@ package weaver
 package framework
 package test
 
-import cats.effect.{ IO, Resource }
+import cats.effect.{ IO, Resource}
 
 object SharedResources extends IOGlobalResource {
+  class RefFactory(init: Int){
+    val generate: Resource[IO, CECompat.Ref[IO, Int]] = Resource.eval(CECompat.Ref.of[IO, Int](init))
+  }
+
   def sharedResources(global: GlobalResourceF.Write[IO]): Resource[IO, Unit] =
     for {
       foo <- Resource.pure[IO, String]("hello world!")
+      bar <- Resource.pure[IO, RefFactory](new RefFactory(0))
       _   <- global.putR(foo)
+      _   <- global.putR(bar)
     } yield ()
 }
 
@@ -33,4 +39,40 @@ class OtherResourceSharingSuite(globalResources: GlobalResourceF.Read[IO])
     IO(expect(sharedInt.isEmpty))
   }
 
+}
+
+class UniqueResourceSuite(global: GlobalRead) extends IOForEachSuite{
+  type Res = CECompat.Ref[IO, Int]
+  def uniqueResource = global.getOrFailR[SharedResources.RefFactory]().flatMap(_.generate)
+
+  override val maxParallelism = 1
+
+  test("start value is set to 0") { refIO =>
+    refIO.get.map(i => expect(i == 0))
+  }
+  test("value is updated locally to 1") { refIO=>
+    refIO.update(_ + 1) *>
+    refIO.get.map(i => expect(i == 1))
+  }
+  test("value is still 0 in another test") { refIO=>
+    refIO.get.map(i => expect(i == 0))
+  }
+}
+
+class SharedResourceSuite(global: GlobalRead) extends IOSuite{
+  type Res = CECompat.Ref[IO, Int]
+  def sharedResource = global.getOrFailR[SharedResources.RefFactory]().flatMap(_.generate)
+
+  override val maxParallelism = 1
+
+  test("start value is set to 0") { refIO =>
+    refIO.get.map(i => expect(i == 0))
+  }
+  test("value is updated in whole suit to 1") { refIO=>
+    refIO.update(_ + 1) *>
+      refIO.get.map(i => expect(i == 1))
+  }
+  test("value is changed to 1 in another test") { refIO=>
+    refIO.get.map(i => expect(i == 1))
+  }
 }


### PR DESCRIPTION
Add IOForEachSuite as a to acquire a new instance of a resource for each test in a suite.

Combining this with global makes it possible to do things that I have not seen in other test frameworks, for instance having the global scope setting up a Database provider and shutting it safely down after all tests are done, but still allowing tests to be written across multiple files, without dependencies on each other and with every test getting a fresh database. 

I have tried to implement and test this pattern in `UniqueResourceSuite` and `SharedResourceSuite`.

If this is something you want to move forward with I would be happy to look at adding it to the docs.