### PR TITLE
Fix #337 and #338 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,11 +42,7 @@ val Version = new {
   }
 
   object CE2 {
-<<<<<<< HEAD
     val fs2        = "2.5.9"
-=======
-    val fs2        = "2.5.8"
->>>>>>> fe2b288... Remove scoverage, bump versions
     val cats       = "2.5.1"
     val zioInterop = "2.5.1.0"
   }

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,11 @@ val Version = new {
   }
 
   object CE2 {
+<<<<<<< HEAD
     val fs2        = "2.5.9"
+=======
+    val fs2        = "2.5.8"
+>>>>>>> fe2b288... Remove scoverage, bump versions
     val cats       = "2.5.1"
     val zioInterop = "2.5.1.0"
   }

--- a/modules/core/src-scala-2/SourceLocationMacro.scala
+++ b/modules/core/src-scala-2/SourceLocationMacro.scala
@@ -18,7 +18,7 @@ trait SourceLocationMacro {
   implicit def fromContext: SourceLocation =
     macro Macros.fromContext
 
-  
+
 }
 
 object macros {
@@ -32,7 +32,10 @@ object macros {
     }
 
     private def getSourceLocation = {
-      val pwd  = java.nio.file.Paths.get("").toAbsolutePath
+      val pwd = SourceLocationHelper
+        .sourcePath(c.compilerSettings)
+        .getOrElse(java.nio.file.Paths.get("").toAbsolutePath)
+
       val p = c.enclosingPosition.source.path
       val abstractFile = c.enclosingPosition.source.file
 

--- a/modules/core/src/weaver/SourceLocation.scala
+++ b/modules/core/src/weaver/SourceLocation.scala
@@ -1,5 +1,8 @@
 package weaver
 
+import java.nio.file.Path
+import java.nio.file.Paths
+
 // kudos to https://github.com/monix/minitest
 final case class SourceLocation(
     filePath: String,
@@ -10,3 +13,20 @@ final case class SourceLocation(
 }
 
 object SourceLocation extends SourceLocationMacro
+
+object SourceLocationHelper {
+
+  private[weaver] def sourcePath(settings: List[String]): Option[Path] = {
+    val sourcePathSettingIndex = settings.indexOf("-sourcepath")
+    if (sourcePathSettingIndex >= 0 && sourcePathSettingIndex < (settings.size - 1)) {
+      Some(settings(sourcePathSettingIndex + 1)).flatMap { s =>
+        try {
+          Some(Paths.get(s))
+        } catch {
+          case _: Throwable => None
+        }
+      }
+    } else None
+  }
+
+}

--- a/modules/framework/cats/test/src/SourceLocationTest.scala
+++ b/modules/framework/cats/test/src/SourceLocationTest.scala
@@ -13,8 +13,7 @@ object SourceLocationTest extends SimpleIOSuite {
     val line    = sourceLocation.line
 
     expect(name.contains("SourceLocationTest.scala")) &&
-    expect(relPath.contains(
-      "modules/framework/cats/test/src/SourceLocationTest.scala")) &&
+    expect.same(relPath, "modules/framework/cats/test/src/SourceLocationTest.scala") &&
     expect(line == 8)
   }
 

--- a/modules/scalacheck/src/weaver/scalacheck/CheckConfig.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/CheckConfig.scala
@@ -1,12 +1,14 @@
 package weaver
 package scalacheck
 
+import org.scalacheck.rng.Seed
+
 case class CheckConfig(
     minimumSuccessful: Int,
     maximumDiscardRatio: Int,
     maximumGeneratorSize: Int,
     perPropertyParallelism: Int,
-    initialSeed: Option[Long]
+    initialSeed: Option[Seed]
 ) {
   assert(maximumDiscardRatio >= 0)
   assert(maximumDiscardRatio <= 100)

--- a/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
@@ -129,7 +129,7 @@ trait Checkers {
       val initial = startSeed(
         Gen.Parameters.default
           .withSize(config.maximumGeneratorSize)
-          .withInitialSeed(config.initialSeed.map(Seed(_))))
+          .withInitialSeed(config.initialSeed))
 
       fs2.Stream.iterate(initial) {
         case (p, s) => (p, s.slide)

--- a/modules/scalacheck/test/src/weaver/scalacheck/CheckersTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/CheckersTest.scala
@@ -67,4 +67,5 @@ object CheckersTest extends SimpleIOSuite with Checkers {
     }
   }
 
+
 }

--- a/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -9,6 +9,7 @@ import cats.syntax.all._
 import weaver.framework._
 
 import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
 
 object PropertyDogFoodTest extends IOSuite {
 
@@ -106,7 +107,7 @@ object Meta {
   object FailedChecks extends SimpleIOSuite with Checkers {
 
     override def checkConfig: CheckConfig =
-      super.checkConfig.copy(perPropertyParallelism = 1, initialSeed = Some(5L))
+      super.checkConfig.copy(perPropertyParallelism = 1, initialSeed = Some(Seed(5L)))
 
     test("foobar") {
       forall { (x: Int) =>


### PR DESCRIPTION
This attempts to parameterise the displayed source path based on the compiler settings, as opposed to using "pwd", which doesn't quite work with bloop as the server will give whatever directory it was started in. 

Right now it is impossible to extract the workspace information from the macro context in Scala 3 (as it possible is in Scala 2) 

David Barri's got a PR in flight to add some API to retrieve macro settings (see https://github.com/lampepfl/dotty/pull/12039), but that's limited to a macro-specific compiler setting, whereas we'd need to access the full compiler-settings to query the workspace from the compiler. 

Let's see how that PR flies with the scala 3 maintainers, and whether we can contribute some api that'd let us query the whole set of compiler settings. 
