### PR TITLE
Play with "provider"-fingerprinted construct

### DIFF
--- a/modules/core/cats/src-ce2/weaver/BaseIOSuites.scala
+++ b/modules/core/cats/src-ce2/weaver/BaseIOSuites.scala
@@ -8,9 +8,11 @@ trait BaseIOSuite extends BaseCatsSuite { self: RunnableSuite[IO] =>
   final implicit protected def contextShift: ContextShift[IO] =
     effectCompat.contextShift
   final implicit protected def timer: Timer[IO] = effectCompat.timer
+  def getSuite: EffectSuite[IO]                 = this
 }
 
 trait BaseFunIOSuite extends FunSuiteF[IO] with BaseCatsSuite {
   override implicit protected def effectCompat: UnsafeRun[EffectType] =
     CatsUnsafeRun
+  def getSuite: EffectSuite[IO] = this
 }

--- a/modules/core/cats/src-ce3/weaver/BaseIOSuite.scala
+++ b/modules/core/cats/src-ce3/weaver/BaseIOSuite.scala
@@ -4,8 +4,10 @@ import cats.effect.IO
 
 trait BaseIOSuite extends RunnableSuite[IO] with BaseCatsSuite {
   implicit protected def effectCompat: UnsafeRun[IO] = CatsUnsafeRun
+  def getSuite: EffectSuite[IO]                      = this
 }
 
 trait BaseFunIOSuite extends FunSuiteF[IO] with BaseCatsSuite {
   implicit protected def effectCompat: UnsafeRun[EffectType] = CatsUnsafeRun
+  def getSuite: EffectSuite[IO]                              = this
 }

--- a/modules/core/cats/src/weaver/Suites.scala
+++ b/modules/core/cats/src/weaver/Suites.scala
@@ -2,7 +2,7 @@ package weaver
 
 import cats.effect.{ IO, Resource }
 
-trait BaseCatsSuite extends EffectSuite[IO]
+trait BaseCatsSuite extends EffectSuite.Provider[IO]
 
 abstract class PureIOSuite
     extends RunnableSuite[IO]

--- a/modules/core/src/weaver/suites.scala
+++ b/modules/core/src/weaver/suites.scala
@@ -49,6 +49,14 @@ trait EffectSuite[F[_]] extends Suite[F] with EffectSuiteAux with SourceLocation
     spec(args).evalMap(report).compile.drain.adaptErr(adaptRunError)
 }
 
+object EffectSuite {
+
+  trait Provider[F[_]]{
+    def getSuite : EffectSuite[F]
+  }
+
+}
+
 @RunWith(classOf[weaver.junit.WeaverRunner])
 abstract class RunnableSuite[F[_]] extends EffectSuite[F] {
   implicit protected def effectCompat: UnsafeRun[EffectType]


### PR DESCRIPTION
This should allow for some flexibility in the effects that suites can use whilst working against a given framework.

See https://github.com/disneystreaming/weaver-test/issues/387