### PR TITLE
#400 add alias for `apply` in `PartiallyAppliedTest`

### DIFF
--- a/modules/core/src/weaver/suites.scala
+++ b/modules/core/src/weaver/suites.scala
@@ -79,6 +79,9 @@ abstract class MutableFSuite[F[_]] extends RunnableSuite[F]  {
     def apply(run: => F[Expectations]) : Unit = registerTest(name)(_ => Test(name.name, run))
     def apply(run : Res => F[Expectations]) : Unit = registerTest(name)(res => Test(name.name, run(res)))
     def apply(run : (Res, Log[F]) => F[Expectations]) : Unit = registerTest(name)(res => Test(name.name, log => run(res, log)))
+
+    // this alias helps using pattern matching on `Res`
+    def usingRes(run : Res => F[Expectations]) : Unit = apply(run)
   }
 
   override def spec(args: List[String]) : Stream[F, TestOutcome] =

--- a/modules/framework/cats/test/src/SharedResourceTests.scala
+++ b/modules/framework/cats/test/src/SharedResourceTests.scala
@@ -1,0 +1,24 @@
+package weaver
+package framework
+package test
+
+import cats.effect.{ IO, Resource }
+
+object SharedResourceTests extends MutableIOSuite {
+  override type Res = (String, Int)
+  override def sharedResource: Resource[IO, (String, Int)] =
+    Resource.pure[IO, (String, Int)](("foo", 5))
+
+  test("should be able to use pattern matching with match") {
+    _ match {
+      case (someString, someInt) =>
+        IO(expect.all(someString == "foo", someInt == 5))
+    }
+  }
+
+  test("should be able to use pattern matching with `usingRes` method")
+    .usingRes {
+      case (someString, someInt) =>
+        IO(expect.all(someString == "foo", someInt == 5))
+    }
+}


### PR DESCRIPTION
resolves https://github.com/disneystreaming/weaver-test/issues/400

I'm more than welcome to hear other candidates for the name. I was also considering names: `match_`, `matching`, `usingResource`, `usingSharedResource`, but I like short names.