### PR TITLE
Clarify plugins required for intellij support

### DIFF
--- a/docs/intellij.md
+++ b/docs/intellij.md
@@ -11,7 +11,7 @@ We (the maintainers) had tried to build an IntelliJ plugin. It worked but its ma
 
 ## Installation
 
-Nothing is needed (as long as weaver is declared correctly in your build).
+Ensure the JUnit plugin is enabled in IntelliJ. Nothing else is needed (as long as weaver is declared correctly in your build). 
 
 ## Usage
 


### PR DESCRIPTION
I hadn't needed this plugin before doing Scala development with ScalaTest.  So I needed to track down this needed adding.