### PR TITLE
Round of upgrades

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,6 @@
-version = "3.0.8"
+version = "3.1.2"
+
+runner.dialect=scala213source3
 
 maxColumn = 80
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ ThisBuild / commands ++= createBuildCommands(allModules)
 
 ThisBuild / scalaVersion := WeaverPlugin.scala213
 
-ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.4.4"
+ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0"
 
 Global / (Test / fork) := true
 Global / (Test / testOptions) += Tests.Argument("--quickstart")
@@ -37,8 +37,8 @@ Global / (Test / testOptions) += Tests.Argument("--quickstart")
 val Version = new {
   object CE3 {
     val fs2        = "3.1.6"
-    val cats       = "3.2.9"
-    val zioInterop = "3.1.1.0"
+    val cats       = "3.3.0"
+    val zioInterop = "3.2.9.0"
   }
 
   object CE2 {
@@ -51,7 +51,7 @@ val Version = new {
   val portableReflect = "1.1.1"
   val junit           = "4.13.2"
   val scalajsStubs    = "1.1.0"
-  val specs2          = "4.13.0"
+  val specs2          = "4.13.1"
   val discipline      = "1.1.5"
   val catsLaws        = "2.7.0"
   val scalacheck      = "1.15.4"
@@ -408,4 +408,13 @@ lazy val versionDump =
 versionDump := {
   val file = (ThisBuild / baseDirectory).value / "version"
   IO.write(file, (Compile / version).value)
+}
+
+ThisBuild / concurrentRestrictions ++= {
+  if (!sys.env.contains("CI")) {
+    Seq(
+      Tags.limitAll(4),
+      Tags.limit(ScalaJSPlugin.autoImport.ScalaJSTags.Link, 1)
+    )
+  } else Seq.empty
 }

--- a/project/WeaverPlugin.scala
+++ b/project/WeaverPlugin.scala
@@ -148,8 +148,8 @@ object WeaverPlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin
   override def trigger  = allRequirements
 
-  lazy val scala212               = "2.12.14"
-  lazy val scala213               = "2.13.6"
+  lazy val scala212               = "2.12.15"
+  lazy val scala213               = "2.13.7"
   lazy val scala3                 = "3.0.2"
   lazy val supportedScalaVersions = List(scala212, scala213, scala3)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // format: off
-addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.9.31")
+addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.9.33")
 addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.7.1")
 addSbtPlugin("com.eed3si9n"         % "sbt-projectmatrix"             % "0.9.0")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"                       % "2.1.1")


### PR DESCRIPTION
1. Scalafmt required an explicit dialect
2. Set concurrent restrictions when **not** on CI - it tries to build 96 tasks by default and my laptop is just refusing
3. Non-controversial upgrades (some cannot be applied because we need to make a decision about bringing Scala 3.1.0)