### PR TITLE
[Tracking] Scala 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,13 +36,13 @@ Global / (Test / testOptions) += Tests.Argument("--quickstart")
 
 val Version = new {
   object CE3 {
-    val fs2        = "3.1.6"
+    val fs2        = "3.2.2"
     val cats       = "3.3.0"
     val zioInterop = "3.2.9.0"
   }
 
   object CE2 {
-    val fs2        = "2.5.9"
+    val fs2        = "2.5.10"
     val cats       = "2.5.4"
     val zioInterop = "2.5.1.0"
   }
@@ -52,7 +52,7 @@ val Version = new {
   val junit           = "4.13.2"
   val scalajsStubs    = "1.1.0"
   val specs2          = "4.13.1"
-  val discipline      = "1.1.5"
+  val discipline      = "1.3.0"
   val catsLaws        = "2.7.0"
   val scalacheck      = "1.15.4"
   val monix           = "3.4.0"

--- a/modules/core/src-scala-3/SourceLocationMacro.scala
+++ b/modules/core/src-scala-3/SourceLocationMacro.scala
@@ -25,7 +25,7 @@ object macros {
 
     val position = Position.ofMacroExpansion
 
-    val psj = position.sourceFile.jpath
+    val psj = position.sourceFile.getJPath.get
     // Comparing roots to workaround a Windows-specific behaviour
     // https://github.com/disneystreaming/weaver-test/issues/364
     val rp = if(pwd.getRoot == psj.getRoot) Expr(pwd.relativize(psj).toString) else Expr(psj.toString)

--- a/project/WeaverPlugin.scala
+++ b/project/WeaverPlugin.scala
@@ -150,7 +150,7 @@ object WeaverPlugin extends AutoPlugin {
 
   lazy val scala212               = "2.12.15"
   lazy val scala213               = "2.13.7"
-  lazy val scala3                 = "3.0.2"
+  lazy val scala3                 = "3.1.0"
   lazy val supportedScalaVersions = List(scala212, scala213, scala3)
 
   lazy val supportedScala2Versions = List(scala212, scala213)


### PR DESCRIPTION
FS2 3.2.2 and discipline 1.3.0 bring in Scala 3.1.0, which would force us to upgrade.

Opening this PR to track and redirect all the Steward PRs that break because of 3.1.0.

Given CE didn't pull the trigger on Scala 3.1.0 (at least CE 3.3.0 didn't), I think we should do it at some point (as we're not at the root of people's dependency tree, but near the leaves) 