### PR TITLE
Renames IOCheckers to Checkers in docs

### DIFF
--- a/docs/scalacheck.md
+++ b/docs/scalacheck.md
@@ -25,7 +25,7 @@ object test extends Tests {
 
 ## Usage
 
-Add the `weaver.scalacheck.IOCheckers` mixin to use ScalaCheck within your test suite.
+Add the `weaver.scalacheck.Checkers` mixin to use ScalaCheck within your test suite.
 
 ```scala mdoc:silent
 import org.scalacheck.Gen


### PR DESCRIPTION
In the latest version `weaver.scalacheck.IOCheckers` has become `weaver.scalacheck.Checkers`.