### PR TITLE
Wait for resources release before ending tests

### DIFF
--- a/modules/framework/src-jvm/SbtTask.scala
+++ b/modules/framework/src-jvm/SbtTask.scala
@@ -11,6 +11,7 @@ private[framework] class SbtTask(
     val taskDef: TaskDef,
     isDone: AtomicBoolean,
     stillRunning: AtomicInteger,
+    waitForResourcesShutdown: java.util.concurrent.Semaphore,
     start: scala.concurrent.Promise[Unit],
     queue: java.util.concurrent.ConcurrentLinkedQueue[SuiteEvent],
     loggerPermit: java.util.concurrent.Semaphore,
@@ -36,6 +37,7 @@ private[framework] class SbtTask(
           case SuiteFinished(_) =>
             finished = true
             if (stillRunning.decrementAndGet == 0) {
+              waitForResourcesShutdown.acquire()
               log(RunFinished(readFailed()))
             }
           case t @ TestFinished(outcome) =>


### PR DESCRIPTION
Fixes #473

A java Semaphore is created initially with 0 permits.  An additional cleanup Resource
is composed around the resources required by the tests.  When the test Resources
complete, the clean Resource releases a permit on the Semaphore.

SBTTask waits for this Semaphore to aquire a permit before wrapping things up.

Kudos to @Baccata for help with the fix.