### PR TITLE
Add example on how to run shared resources with `sbt testOnly`

### DIFF
--- a/docs/global_resources.md
+++ b/docs/global_resources.md
@@ -87,6 +87,8 @@ Some build tools provide a "testOnly" (or equivalent) command that lets you test
 An example of how to do this:
 
 ```scala mdoc
+package weaver.example
+
 import cats.effect.{ IO, Resource }
 import weaver._
 
@@ -115,6 +117,24 @@ class MySuite(global: GlobalRead) extends IOSuite {
     IO(expect(sharedString == "hello world!"))
   }
 }
+
+class MyOtherSuite(global: GlobalRead) extends IOSuite {
+  import MyResources._
+
+  override type Res = String
+
+  def sharedResource: Resource[IO, String] = sharedResourceOrFallback(global)
+
+  test("oops, forgot something here") { sharedString =>    
+    IO(expect(sharedString == "hello world!"))
+  }
+}
+```
+
+Run through SBT with:
+
+```
+sbt testOnly *My*Suite weaver.example.MyResources
 ```
 
 ## Regarding global resource indexing


### PR DESCRIPTION
Hi all,

I'm updated the docs with instructions on how to specify a shared resource to `sbt testOnly`. This was part of the reason for my raising [Using testOnly with multiple matches results in multiple shared resource instantiations](https://github.com/disneystreaming/weaver-test/issues/480) and I think it could help others in the future.