### PR TITLE
Update documentation wrt mill testFramework

### DIFF
--- a/docs/cats_effect_usage.md
+++ b/docs/cats_effect_usage.md
@@ -19,7 +19,7 @@ object test extends Tests {
   def ivyDeps = Agg(
     ivy"com.disneystreaming::weaver-cats:@VERSION@"
   )
-  def testFrameworks = Seq("weaver.framework.CatsEffect")
+  def testFramework = "weaver.framework.CatsEffect"
 }
 ```
 

--- a/docs/monix_bio_usage.md
+++ b/docs/monix_bio_usage.md
@@ -25,7 +25,7 @@ object test extends Tests {
   def ivyDeps = Agg(
     ivy"com.disneystreaming::weaver-monix-bio:@VERSION@"
   )
-  def testFrameworks = Seq("weaver.framework.MonixBIO")
+  def testFramework = "weaver.framework.MonixBIO"
 }
 ```
 

--- a/docs/monix_usage.md
+++ b/docs/monix_usage.md
@@ -19,7 +19,7 @@ object test extends Tests {
   def ivyDeps = Agg(
     ivy"com.disneystreaming::weaver-monix:@VERSION@"
   )
-  def testFrameworks = Seq("weaver.framework.Monix")
+  def testFramework = "weaver.framework.Monix"
 }
 ```
 

--- a/docs/zio_usage.md
+++ b/docs/zio_usage.md
@@ -19,7 +19,7 @@ object test extends Tests {
   def ivyDeps = Agg(
     ivy"com.disneystreaming::weaver-zio:@VERSION@"
   )
-  def testFrameworks = Seq("weaver.framework.ZIO")
+  def testFramework = "weaver.framework.ZIO"
 }
 ```
 


### PR DESCRIPTION
See mill's source:

```
scalalib/src/TestModule.scala:  @deprecated("Use testFramework instead.", "mill after 0.9.6")
scalalib/src/TestModule.scala:  def testFrameworks: T[Seq[String]] = T { Seq.empty[String] }
scalalib/src/TestModule.scala:  def testFramework: T[String] = T
```