### PR TITLE
Fix ZIOSuite test timings when clock is overridden

### DIFF
--- a/modules/core/zio/src/weaver/ziocompat/Live.scala
+++ b/modules/core/zio/src/weaver/ziocompat/Live.scala
@@ -1,0 +1,24 @@
+package weaver
+package ziocompat
+
+import zio.{ IO, URLayer, ZEnv, ZIO }
+
+/**
+ * Service used for getting the real environment during tests. This is useful
+ * for timing or getting random values during tests. For example, getting a
+ * random port for starting servers or timing an action with the real clock.
+ * This pattern is inspired by ZIO-test
+ */
+object Live {
+  trait Service {
+    def live[E, A](zio: ZIO[ZEnv, E, A]): IO[E, A]
+  }
+
+  def live[E, A](zio: ZIO[ZEnv, E, A]): ZIO[Live, E, A] =
+    ZIO.serviceWith[Service](_.live(zio))
+
+  def apply(): URLayer[ZEnv, Live] = ZIO.environment[ZEnv].map(env =>
+    new Service {
+      override def live[E, A](zio: ZIO[ZEnv, E, A]): IO[E, A] = zio.provide(env)
+    }).toLayer
+}

--- a/modules/core/zio/src/weaver/ziocompat/Test.scala
+++ b/modules/core/zio/src/weaver/ziocompat/Test.scala
@@ -16,11 +16,11 @@ object Test {
       f: ZIO[Env[R], Throwable, Expectations]
   ): ZIO[Env[R], Nothing, TestOutcome] =
     for {
-      start <- zio.clock.currentTime(TimeUnit.MILLISECONDS)
+      start <- Live.live(zio.clock.currentTime(TimeUnit.MILLISECONDS))
       res <- f
         .unrefine { case NonFatal(e) => e }
         .fold(Result.from, Result.fromAssertion)
-      end  <- zio.clock.currentTime(TimeUnit.MILLISECONDS)
+      end  <- Live.live(zio.clock.currentTime(TimeUnit.MILLISECONDS))
       logs <- LogModule.logs
     } yield TestOutcome(name, (end - start).millis, res, logs)
 

--- a/modules/core/zio/src/weaver/ziocompat/package.scala
+++ b/modules/core/zio/src/weaver/ziocompat/package.scala
@@ -18,9 +18,10 @@ package object ziocompat {
     def logs: URIO[LogModule, Chain[Log.Entry]] = ZIO.accessM(_.get.logs)
   }
   type LogModule = Has[LogModule.Service]
+  type Live      = Has[Live.Service]
 
   type T[A]             = RIO[ZEnv, A]
-  type Env[R <: Has[_]] = ZEnv with R with LogModule
+  type Env[R <: Has[_]] = ZEnv with Live with R with LogModule
 
   val unitTag = implicitly[Tag[Unit]]
   type ZIOSuite[R <: Has[_]] = MutableZIOSuite[R]

--- a/modules/core/zio/src/weaver/ziocompat/suites.scala
+++ b/modules/core/zio/src/weaver/ziocompat/suites.scala
@@ -49,9 +49,10 @@ abstract class BaseMutableZIOSuite[Res <: Has[_]](implicit tag: Tag[Res])
       else {
         for {
           ref <- Stream.eval(FiberRef.make(Chain.empty[Log.Entry]))
-          testLayer: RLayer[ZEnv, LogModule with ZEnv] =
-            ZEnv.any ++ ZLayer.fromService[Clock.Service, LogModule.Service](
-              FiberRefLog(ref, _))
+          testLayer: RLayer[ZEnv, Live with LogModule with ZEnv] =
+            ZEnv.any >+> Live() ++ ZLayer.fromService[
+              Clock.Service,
+              LogModule.Service](FiberRefLog(ref, _))
           suiteLayer =
             (testLayer >+> sharedLayer).passthrough
           resource <- Stream.resource(suiteLayer.build.toResourceZIO)


### PR DESCRIPTION
@Baccata as discussed a couple of weeks ago, here is a PR to fix the test timings when using a mocked clock in the shared layer.  This is my first weaver, so keen if you have any feedback