### PR TITLE
Remove unused ZIO SharedResourceModule

### DIFF
--- a/modules/core/zio/src/weaver/ziocompat/SharedResourceModule.scala
+++ b/modules/core/zio/src/weaver/ziocompat/SharedResourceModule.scala
@@ -1,5 +1,0 @@
-package weaver.ziocompat
-
-trait SharedResourceModule[A] { self =>
-  def sharedResource: A
-}


### PR DESCRIPTION
It seems that SharedResourceModule is not used anywhere. I am not sure of the history, however leaving it in the API gives users a false sense that something is actually working where it is not anymore. I don't know about the weaver versioning strategy or roadmap, so not sure when an appropriate time would be to merge this.