### PR TITLE
Upgrade libraries, Scala.js and Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java: [adopt@1.8]
-        scalaVersion: ["2_12", "2_13", "3_0"]
+        scalaVersion: ["2_12", "2_13", "3"]
         scalaPlatform: ["jvm", "js"]
         ceVersion: ["CE2", "CE3"]
     runs-on: ${{ matrix.os }}

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.5.3"
+version = "3.5.8"
 
 runner.dialect=scala213source3
 

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ Global / (Test / testOptions) += Tests.Argument("--quickstart")
 
 val Version = new {
   object CE3 {
-    val fs2        = "3.1.6"
+    val fs2        = "3.2.9"
     val cats       = "3.3.13"
     val zioInterop = "3.2.9.1"
   }
@@ -47,18 +47,19 @@ val Version = new {
     val zioInterop = "2.5.1.0"
   }
 
-  val expecty         = "0.15.4"
-  val portableReflect = "1.1.2"
-  val junit           = "4.13.2"
-  val scalajsStubs    = "1.1.0"
-  val specs2          = "4.15.0"
-  val discipline      = "1.4.0"
-  val catsLaws        = "2.7.0"
-  val scalacheck      = "1.15.4"
-  val monix           = "3.4.0"
-  val monixBio        = "1.2.0"
-  val testInterface   = "1.0"
-  val scalaJavaTime   = "2.3.0"
+  val expecty          = "0.15.4"
+  val portableReflect  = "1.1.2"
+  val junit            = "4.13.2"
+  val scalajsStubs     = "1.1.0"
+  val specs2           = "4.16.1"
+  val discipline       = "1.5.1"
+  val catsLaws         = "2.8.0"
+  val scalacheck       = "1.16.0"
+  val monix            = "3.4.1"
+  val monixBio         = "1.2.0"
+  val testInterface    = "1.0"
+  val scalaJavaTime    = "2.4.0"
+  val scalajsMacroTask = "1.0.0"
 }
 
 lazy val root = project
@@ -290,6 +291,7 @@ lazy val coreCats = projectMatrix
   .full
   .dependsOn(core)
   .settings(WeaverPlugin.simpleLayout)
+  .settings(scalaJSMacroTask)
   .settings(name := "cats-core")
 
 lazy val coreMonix = projectMatrix
@@ -420,3 +422,12 @@ ThisBuild / concurrentRestrictions ++= {
     )
   } else Seq.empty
 }
+
+lazy val scalaJSMacroTask: Seq[Def.Setting[_]] = Seq(
+  libraryDependencies ++= {
+    if (virtualAxes.value.contains(VirtualAxis.js))
+      Seq("org.scala-js" %%% "scala-js-macrotask-executor" % Version.scalajsMacroTask)
+    else
+      Seq.empty
+  }
+)

--- a/modules/core/cats/src-ce2-js/PlatformECCompat.scala
+++ b/modules/core/cats/src-ce2-js/PlatformECCompat.scala
@@ -1,0 +1,9 @@
+package weaver
+
+import scala.concurrent.ExecutionContext
+
+import org.scalajs.macrotaskexecutor.MacrotaskExecutor
+
+object PlatformECCompat {
+  val ec: ExecutionContext = MacrotaskExecutor
+}

--- a/modules/core/cats/src-ce2-js/PlatformECCompat.scala
+++ b/modules/core/cats/src-ce2-js/PlatformECCompat.scala
@@ -4,6 +4,6 @@ import scala.concurrent.ExecutionContext
 
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor
 
-object PlatformECCompat {
+private[weaver] object PlatformECCompat {
   val ec: ExecutionContext = MacrotaskExecutor
 }

--- a/modules/core/cats/src-ce2-jvm/PlatformECCompat.scala
+++ b/modules/core/cats/src-ce2-jvm/PlatformECCompat.scala
@@ -1,0 +1,7 @@
+package weaver
+
+import scala.concurrent.ExecutionContext
+
+object PlatformECCompat {
+  val ec: ExecutionContext = ExecutionContext.global
+}

--- a/modules/core/cats/src-ce2-jvm/PlatformECCompat.scala
+++ b/modules/core/cats/src-ce2-jvm/PlatformECCompat.scala
@@ -2,6 +2,6 @@ package weaver
 
 import scala.concurrent.ExecutionContext
 
-object PlatformECCompat {
+private[weaver] object PlatformECCompat {
   val ec: ExecutionContext = ExecutionContext.global
 }

--- a/modules/core/cats/src-ce2/weaver/CatsUnsafeRun.scala
+++ b/modules/core/cats/src-ce2/weaver/CatsUnsafeRun.scala
@@ -1,7 +1,5 @@
 package weaver
 
-import scala.concurrent.ExecutionContext
-
 import cats.effect.{ ContextShift, IO, Timer }
 
 object CatsUnsafeRun extends CatsUnsafeRun
@@ -11,9 +9,10 @@ trait CatsUnsafeRun extends UnsafeRun[IO] {
   type CancelToken = IO[Unit]
 
   override implicit val contextShift: ContextShift[IO] =
-    IO.contextShift(ExecutionContext.global)
+    IO.contextShift(PlatformECCompat.ec)
+
   override implicit val timer: Timer[IO] =
-    IO.timer(ExecutionContext.global)
+    IO.timer(PlatformECCompat.ec)
 
   override implicit val effect   = IO.ioConcurrentEffect(contextShift)
   override implicit val parallel = IO.ioParallel(contextShift)

--- a/modules/core/src-scala-3/SourceLocationMacro.scala
+++ b/modules/core/src-scala-3/SourceLocationMacro.scala
@@ -25,7 +25,7 @@ object macros {
 
     val position = Position.ofMacroExpansion
 
-    val psj = position.sourceFile.jpath
+    val psj = position.sourceFile.getJPath.get
     // Comparing roots to workaround a Windows-specific behaviour
     // https://github.com/disneystreaming/weaver-test/issues/364
     val rp = if(pwd.getRoot == psj.getRoot) Expr(pwd.relativize(psj).toString) else Expr(psj.toString)

--- a/project/WeaverPlugin.scala
+++ b/project/WeaverPlugin.scala
@@ -148,9 +148,9 @@ object WeaverPlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin
   override def trigger  = allRequirements
 
-  lazy val scala212               = "2.12.15"
-  lazy val scala213               = "2.13.7"
-  lazy val scala3                 = "3.0.2"
+  lazy val scala212               = "2.12.16"
+  lazy val scala213               = "2.13.8"
+  lazy val scala3                 = "3.1.3"
   lazy val supportedScalaVersions = List(scala212, scala213, scala3)
 
   lazy val supportedScala2Versions = List(scala212, scala213)
@@ -404,7 +404,7 @@ object WeaverPlugin extends AutoPlugin {
             if (projectId.endsWith(scala3Suffix) && !projectId.endsWith(
                 ce3Suffix)) {
               projectId = projectId.dropRight(scala3Suffix.length)
-              "3_0"
+              "3"
             } else if (projectId.endsWith(scala212Suffix)) {
               projectId = projectId.dropRight(scala212Suffix.length)
               "2_12"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // format: off
-addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.9.33")
+addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.10.1")
 addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.10.1")
 addSbtPlugin("com.eed3si9n"         % "sbt-projectmatrix"             % "0.9.0")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"                       % "2.1.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 // format: off
 addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.9.33")
-addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.7.1")
+addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.10.1")
 addSbtPlugin("com.eed3si9n"         % "sbt-projectmatrix"             % "0.9.0")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"                       % "2.1.1")
 addSbtPlugin("com.dwijnand"         % "sbt-dynver"                    % "4.1.1")
-addSbtPlugin("org.xerial.sbt"       % "sbt-sonatype"                  % "3.9.11")
+addSbtPlugin("org.xerial.sbt"       % "sbt-sonatype"                  % "3.9.13")
 addSbtPlugin("org.scalameta"        % "sbt-scalafmt"                  % "2.4.6")
-addSbtPlugin("org.scalameta"        % "sbt-mdoc"                      % "2.3.1")
+addSbtPlugin("org.scalameta"        % "sbt-mdoc"                      % "2.3.2")
 addSbtPlugin("com.eed3si9n"         % "sbt-buildinfo"                 % "0.11.0")


### PR DESCRIPTION
Also bring in the macrotask dependency for Scala.js

I don't think the decision to bump Scala to 3.1.x is controversial anymore - Cats did it in 2.8.0, 20 days ago.

This helps clear out the path of upgrades to the great schism (#481), giving us a sort of cleanish slate.

I couldn't do `zio 2.5.1.0 -> 2.5.1.1` because I got 59 compilation errors and... yeah.

If this goes green, I'll just close all the individual steward PRs and iterate here instead.

Closes #476 