### PR TITLE
Ignored test name tag

### DIFF
--- a/docs/intellij.md
+++ b/docs/intellij.md
@@ -23,7 +23,7 @@ When test suites are open in IntelliJ, buttons appear to the left of the editor 
 
 ### Ignorning individual tests
 
-An `.ignored` extension method is provided on strings, and can be used when declaring tests. All tests that are tagged with `.ignored` will be ignored in the test suite, including any that are tagged with `.only`.
+An `.ignore` extension method is provided on strings, and can be used when declaring tests. All tests that are tagged with `.ignore` will be ignored in the test suite, including any that are tagged with `.only`.
 
 ```scala mdoc  
 import weaver._
@@ -35,7 +35,7 @@ object MySuite extends SimpleIOSuite {
     IO(success)
   }
 
-  test("do not test this".ignored) {
+  test("do not test this".ignore) {
     IO.raiseError(new Throwable("Boom"))
   }
 
@@ -44,7 +44,7 @@ object MySuite extends SimpleIOSuite {
 
 ### Running individual tests
 
-A `.only` extension method is provided on strings, and can be used when declaring tests. When at least one test is "tagged" as such in a suite, weaver will ignore all tests but the ones that have the "only" tag. Note: `.ignored` has precedence over `.only`.
+A `.only` extension method is provided on strings, and can be used when declaring tests. When at least one test is "tagged" as such in a suite, weaver will ignore all tests but the ones that have the "only" tag. Note: `.ignore` has precedence over `.only`.
 
 ```scala mdoc  
 import weaver._

--- a/docs/intellij.md
+++ b/docs/intellij.md
@@ -21,9 +21,30 @@ When test suites are open in IntelliJ, buttons appear to the left of the editor 
 
 ![](../img/intellij_usage.png)
 
+### Ignorning individual tests
+
+An `.ignored` extension method is provided on strings, and can be used when declaring tests. All tests that are tagged with `.ignored` will be ignored in the test suite, including any that are tagged with `.only`.
+
+```scala mdoc  
+import weaver._
+import cats.effect._
+
+object MySuite extends SimpleIOSuite {
+
+  test("test this") {
+    IO(success)
+  }
+
+  test("do not test this".ignored) {
+    IO.raiseError(new Throwable("Boom"))
+  }
+
+}
+```
+
 ### Running individual tests
 
-A `.only` extension method is provided on strings, and can be used when declaring tests. When at least one test is "tagged" as such in a suite, weaver will ignore all tests but the ones that have the "only" tag.
+A `.only` extension method is provided on strings, and can be used when declaring tests. When at least one test is "tagged" as such in a suite, weaver will ignore all tests but the ones that have the "only" tag. Note: `.ignored` has precedence over `.only`.
 
 ```scala mdoc  
 import weaver._

--- a/docs/intellij.md
+++ b/docs/intellij.md
@@ -29,7 +29,7 @@ An `.ignore` extension method is provided on strings, and can be used when decla
 import weaver._
 import cats.effect._
 
-object MySuite extends SimpleIOSuite {
+object MyIgnoreSuite extends SimpleIOSuite {
 
   test("test this") {
     IO(success)
@@ -50,7 +50,7 @@ A `.only` extension method is provided on strings, and can be used when declarin
 import weaver._
 import cats.effect._
 
-object MySuite extends SimpleIOSuite {
+object MyOnlySuite extends SimpleIOSuite {
 
   test("test this".only) {
     IO(success)

--- a/modules/core/src-jvm/weaver/junit/WeaverRunner.scala
+++ b/modules/core/src-jvm/weaver/junit/WeaverRunner.scala
@@ -59,7 +59,8 @@ class WeaverRunner(cls: Class[_], dummy: Boolean)
   }
 
   private def notifyIgnored(notifier: RunNotifier): Unit = {
-    val (taggedIgnored, rest) = suite.plan.partition(_.tags(TestName.Tags.ignore))
+    val (taggedIgnored, rest) =
+      suite.plan.partition(_.tags(TestName.Tags.ignore))
     val (only, ignored) = rest.partition(_.tags(TestName.Tags.only))
     val toNotifyIgnored = if (only.nonEmpty) {
       taggedIgnored ++ ignored

--- a/modules/core/src-jvm/weaver/junit/WeaverRunner.scala
+++ b/modules/core/src-jvm/weaver/junit/WeaverRunner.scala
@@ -59,7 +59,7 @@ class WeaverRunner(cls: Class[_], dummy: Boolean)
   }
 
   private def notifyIgnored(notifier: RunNotifier): Unit = {
-    val (taggedIgnored, rest) = suite.plan.partition(_.tags(TestName.Tags.ignored))
+    val (taggedIgnored, rest) = suite.plan.partition(_.tags(TestName.Tags.ignore))
     val (only, ignored) = rest.partition(_.tags(TestName.Tags.only))
     val toNotifyIgnored = if (only.nonEmpty) {
       taggedIgnored ++ ignored

--- a/modules/core/src-jvm/weaver/junit/WeaverRunner.scala
+++ b/modules/core/src-jvm/weaver/junit/WeaverRunner.scala
@@ -59,13 +59,17 @@ class WeaverRunner(cls: Class[_], dummy: Boolean)
   }
 
   private def notifyIgnored(notifier: RunNotifier): Unit = {
-    val (only, ignored) = suite.plan.partition(_.tags(TestName.Tags.only))
-    if (only.nonEmpty) {
-      ignored
-        .map(_.name)
-        .map(testDescriptions)
-        .foreach(notifier.fireTestIgnored)
+    val (taggedIgnored, rest) = suite.plan.partition(_.tags(TestName.Tags.ignored))
+    val (only, ignored) = rest.partition(_.tags(TestName.Tags.only))
+    val toNotifyIgnored = if (only.nonEmpty) {
+      taggedIgnored ++ ignored
+    } else {
+      taggedIgnored
     }
+    toNotifyIgnored
+      .map(_.name)
+      .map(testDescriptions)
+      .foreach(notifier.fireTestIgnored)
   }
 
   private def desc(outcome: TestOutcome): Description =

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -150,8 +150,8 @@ object Expectations {
     }
 
     implicit class StringOps(str: String) {
-      def ignored(implicit loc: SourceLocation): TestName =
-        new TestName(str, loc, Set.empty).ignored
+      def ignore(implicit loc: SourceLocation): TestName =
+        new TestName(str, loc, Set.empty).ignore
       def only(implicit loc: SourceLocation): TestName =
         new TestName(str, loc, Set.empty).only
       def tagged(tag: String)(implicit loc: SourceLocation): TestName =

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -150,6 +150,8 @@ object Expectations {
     }
 
     implicit class StringOps(str: String) {
+      def ignored(implicit loc: SourceLocation): TestName =
+        new TestName(str, loc, Set.empty).ignored
       def only(implicit loc: SourceLocation): TestName =
         new TestName(str, loc, Set.empty).only
       def tagged(tag: String)(implicit loc: SourceLocation): TestName =

--- a/modules/core/src/weaver/TestName.scala
+++ b/modules/core/src/weaver/TestName.scala
@@ -9,6 +9,7 @@ package weaver
 case class TestName(name: String, location: SourceLocation, tags: Set[String]) {
   def tagged(str: String): TestName = this.copy(tags = tags + str)
   def only: TestName                = tagged(TestName.Tags.only)
+  def ignored: TestName             = tagged(TestName.Tags.ignored)
 }
 
 object TestName {
@@ -18,5 +19,6 @@ object TestName {
 
   object Tags {
     val only = "only"
+    val ignored = "ignored"
   }
 }

--- a/modules/core/src/weaver/TestName.scala
+++ b/modules/core/src/weaver/TestName.scala
@@ -9,7 +9,7 @@ package weaver
 case class TestName(name: String, location: SourceLocation, tags: Set[String]) {
   def tagged(str: String): TestName = this.copy(tags = tags + str)
   def only: TestName                = tagged(TestName.Tags.only)
-  def ignored: TestName             = tagged(TestName.Tags.ignored)
+  def ignore: TestName             = tagged(TestName.Tags.ignore)
 }
 
 object TestName {
@@ -19,6 +19,6 @@ object TestName {
 
   object Tags {
     val only = "only"
-    val ignored = "ignored"
+    val ignore = "ignore"
   }
 }

--- a/modules/core/src/weaver/TestName.scala
+++ b/modules/core/src/weaver/TestName.scala
@@ -9,7 +9,7 @@ package weaver
 case class TestName(name: String, location: SourceLocation, tags: Set[String]) {
   def tagged(str: String): TestName = this.copy(tags = tags + str)
   def only: TestName                = tagged(TestName.Tags.only)
-  def ignore: TestName             = tagged(TestName.Tags.ignore)
+  def ignore: TestName              = tagged(TestName.Tags.ignore)
 }
 
 object TestName {
@@ -18,7 +18,7 @@ object TestName {
     TestName(s, location, Set.empty)
 
   object Tags {
-    val only = "only"
+    val only   = "only"
     val ignore = "ignore"
   }
 }

--- a/modules/core/src/weaver/suites.scala
+++ b/modules/core/src/weaver/suites.scala
@@ -95,10 +95,11 @@ abstract class MutableFSuite[F[_]] extends RunnableSuite[F]  {
   override def spec(args: List[String]) : Stream[F, TestOutcome] =
     synchronized {
       if (!isInitialized) isInitialized = true
-      val testsTaggedOnly = testSeq.filter(_._1.tags(TestName.Tags.only))
+      val testsNotIgnored = testSeq.filterNot(_._1.tags(TestName.Tags.ignored))
+      val testsTaggedOnly = testsNotIgnored.filter(_._1.tags(TestName.Tags.only))
       val filteredTests = if (testsTaggedOnly.isEmpty) {
         val argsFilter = Filters.filterTests(this.name)(args)
-        testSeq.collect {
+        testsNotIgnored.collect {
           case (name, test) if argsFilter(name) => test
         }
       } else testsTaggedOnly.map(_._2)

--- a/modules/core/src/weaver/suites.scala
+++ b/modules/core/src/weaver/suites.scala
@@ -95,7 +95,7 @@ abstract class MutableFSuite[F[_]] extends RunnableSuite[F]  {
   override def spec(args: List[String]) : Stream[F, TestOutcome] =
     synchronized {
       if (!isInitialized) isInitialized = true
-      val testsNotIgnored = testSeq.filterNot(_._1.tags(TestName.Tags.ignored))
+      val testsNotIgnored = testSeq.filterNot(_._1.tags(TestName.Tags.ignore))
       val testsTaggedOnly = testsNotIgnored.filter(_._1.tags(TestName.Tags.only))
       val filteredTests = if (testsTaggedOnly.isEmpty) {
         val argsFilter = Filters.filterTests(this.name)(args)

--- a/modules/framework/cats/test/src-jvm/junit/JUnitRunnerTests.scala
+++ b/modules/framework/cats/test/src-jvm/junit/JUnitRunnerTests.scala
@@ -55,30 +55,30 @@ object JUnitRunnerTests extends IOSuite {
   }
 
   test("Only tests tagged with only are ran (unless also tagged ignored)") { blocker =>
-    run(blocker, Meta.IgnoredAndOnly).map { notifications =>
+    run(blocker, Meta.IgnoreAndOnly).map { notifications =>
       val expected = List(
-        TestSuiteStarted("weaver.junit.Meta$IgnoredAndOnly$"),
-        TestIgnored("only and ignored(weaver.junit.Meta$IgnoredAndOnly$)"),
-        TestIgnored("is ignored(weaver.junit.Meta$IgnoredAndOnly$)"),
-        TestIgnored("not tagged(weaver.junit.Meta$IgnoredAndOnly$)"),
-        TestStarted("only(weaver.junit.Meta$IgnoredAndOnly$)"),
-        TestFinished("only(weaver.junit.Meta$IgnoredAndOnly$)"),
-        TestSuiteFinished("weaver.junit.Meta$IgnoredAndOnly$")
+        TestSuiteStarted("weaver.junit.Meta$IgnoreAndOnly$"),
+        TestIgnored("only and ignored(weaver.junit.Meta$IgnoreAndOnly$)"),
+        TestIgnored("is ignored(weaver.junit.Meta$IgnoreAndOnly$)"),
+        TestIgnored("not tagged(weaver.junit.Meta$IgnoreAndOnly$)"),
+        TestStarted("only(weaver.junit.Meta$IgnoreAndOnly$)"),
+        TestFinished("only(weaver.junit.Meta$IgnoreAndOnly$)"),
+        TestSuiteFinished("weaver.junit.Meta$IgnoreAndOnly$")
       )
       expect.same(notifications, expected)
     }
   }
 
   test("Tests tagged with ignore are ignored") { blocker =>
-    run(blocker, Meta.Ignored).map { notifications =>
+    run(blocker, Meta.Ignore).map { notifications =>
       val expected = List(
-        TestSuiteStarted("weaver.junit.Meta$Ignored$"),
-        TestIgnored("is ignored(weaver.junit.Meta$Ignored$)"),
-        TestStarted("not ignored 1(weaver.junit.Meta$Ignored$)"),
-        TestFinished("not ignored 1(weaver.junit.Meta$Ignored$)"),
-        TestStarted("not ignored 2(weaver.junit.Meta$Ignored$)"),
-        TestFinished("not ignored 2(weaver.junit.Meta$Ignored$)"),
-        TestSuiteFinished("weaver.junit.Meta$Ignored$")
+        TestSuiteStarted("weaver.junit.Meta$Ignore$"),
+        TestIgnored("is ignored(weaver.junit.Meta$Ignore$)"),
+        TestStarted("not ignored 1(weaver.junit.Meta$Ignore$)"),
+        TestFinished("not ignored 1(weaver.junit.Meta$Ignore$)"),
+        TestStarted("not ignored 2(weaver.junit.Meta$Ignore$)"),
+        TestFinished("not ignored 2(weaver.junit.Meta$Ignore$)"),
+        TestSuiteFinished("weaver.junit.Meta$Ignore$")
       )
       expect.same(notifications, expected)
     }
@@ -177,7 +177,7 @@ object Meta {
 
   }
 
-  object Ignored extends SimpleIOSuite {
+  object Ignore extends SimpleIOSuite {
 
     override def maxParallelism: Int = 1
 
@@ -189,13 +189,13 @@ object Meta {
       success
     }
 
-    pureTest("is ignored".ignored) {
+    pureTest("is ignored".ignore) {
       failure("foo")
     }
 
   }
 
-  object IgnoredAndOnly extends SimpleIOSuite {
+  object IgnoreAndOnly extends SimpleIOSuite {
 
     override def maxParallelism: Int = 1
 
@@ -207,11 +207,11 @@ object Meta {
       failure("foo")
     }
 
-    pureTest("only and ignored".only.ignored) {
+    pureTest("only and ignored".only.ignore) {
       failure("foo")
     }
 
-    pureTest("is ignored".ignored) {
+    pureTest("is ignored".ignore) {
       failure("foo")
     }
 

--- a/modules/framework/cats/test/src-jvm/junit/JUnitRunnerTests.scala
+++ b/modules/framework/cats/test/src-jvm/junit/JUnitRunnerTests.scala
@@ -54,19 +54,20 @@ object JUnitRunnerTests extends IOSuite {
     }
   }
 
-  test("Only tests tagged with only are ran (unless also tagged ignored)") { blocker =>
-    run(blocker, Meta.IgnoreAndOnly).map { notifications =>
-      val expected = List(
-        TestSuiteStarted("weaver.junit.Meta$IgnoreAndOnly$"),
-        TestIgnored("only and ignored(weaver.junit.Meta$IgnoreAndOnly$)"),
-        TestIgnored("is ignored(weaver.junit.Meta$IgnoreAndOnly$)"),
-        TestIgnored("not tagged(weaver.junit.Meta$IgnoreAndOnly$)"),
-        TestStarted("only(weaver.junit.Meta$IgnoreAndOnly$)"),
-        TestFinished("only(weaver.junit.Meta$IgnoreAndOnly$)"),
-        TestSuiteFinished("weaver.junit.Meta$IgnoreAndOnly$")
-      )
-      expect.same(notifications, expected)
-    }
+  test("Only tests tagged with only are ran (unless also tagged ignored)") {
+    blocker =>
+      run(blocker, Meta.IgnoreAndOnly).map { notifications =>
+        val expected = List(
+          TestSuiteStarted("weaver.junit.Meta$IgnoreAndOnly$"),
+          TestIgnored("only and ignored(weaver.junit.Meta$IgnoreAndOnly$)"),
+          TestIgnored("is ignored(weaver.junit.Meta$IgnoreAndOnly$)"),
+          TestIgnored("not tagged(weaver.junit.Meta$IgnoreAndOnly$)"),
+          TestStarted("only(weaver.junit.Meta$IgnoreAndOnly$)"),
+          TestFinished("only(weaver.junit.Meta$IgnoreAndOnly$)"),
+          TestSuiteFinished("weaver.junit.Meta$IgnoreAndOnly$")
+        )
+        expect.same(notifications, expected)
+      }
   }
 
   test("Tests tagged with ignore are ignored") { blocker =>


### PR DESCRIPTION
Add an `ignored` test name tag to easily ignore individual tests.

We had some internal discussions about adding something like this.

The only thing I'm not sure of is using `.ignored` vs `.ignore` (including the "d" or not)