### PR TITLE
Make parallel/sequential suites in DogFood lazy resources tests deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: ["master"]
+    branches: ["master", "series/*"]
   push:
-    branches: ["master"]
+    branches: ["master", "series/*"]
     tags: ["v*"]
 
 jobs:

--- a/modules/framework/cats/test/src-jvm/MetaJVM.scala
+++ b/modules/framework/cats/test/src-jvm/MetaJVM.scala
@@ -4,10 +4,8 @@ package test
 
 import java.io.File
 
-import scala.concurrent.duration._
-
 import cats.effect._
-import cats.effect.std.CyclicBarrier
+import cats.effect.std.{ CyclicBarrier, Semaphore }
 import cats.syntax.all._
 
 // The build tool will only detect and run top-level test suites. We can however nest objects
@@ -65,13 +63,31 @@ object MetaJVM {
     } yield (i, f, t, u)
   }
 
+  case class SequentialAccess(permit: Resource[IO, Unit])
+
   object LazyGlobal extends GlobalResource {
     def sharedResources(global: weaver.GlobalWrite): Resource[IO, Unit] =
       Resource.eval {
         for {
-          initialised   <- Ref[IO].of(0)
-          finalised     <- Ref[IO].of(0)
-          totalUses     <- Ref[IO].of(0)
+          initialised <- Ref[IO].of(0)
+          finalised   <- Ref[IO].of(0)
+          totalUses   <- Ref[IO].of(0)
+          /**
+           * NOTE: the number 3 refers to the current number of instantiated
+           * suites in the DogFoodTestsJVM spec, tests involving "global lazy
+           * resources"
+           *
+           * If you do either of the following:
+           *
+           *   - Change the number of LazyAccessParallel suites in "global lazy
+           *     resources (parallel)" test
+           *
+           *   - Change the number below 3. Add another test to the
+           *     LazyAccessParallel spec below
+           *
+           * You are very likely to face a very confusing non-deterministic
+           * behaviour. Those numbers need to be kept in sync.
+           */
           parallelLatch <- CyclicBarrier[IO](3)
           resource =
             Resource.eval(Ref[IO].of(0)).flatMap { uses =>
@@ -88,7 +104,10 @@ object MetaJVM {
                                                       uses,
                                                       synchronisation))
             }
+          sequential <-
+            Semaphore[IO](1).map(_.permit).map(SequentialAccess.apply)
           _ <- global.putLazy(resource)
+          _ <- global.put(sequential)
         } yield ()
       }
   }
@@ -115,9 +134,13 @@ object MetaJVM {
   abstract class LazyAccessSequential(global: GlobalRead, index: Int)
       extends IOSuite {
     type Res = LazyState
-    def sharedResource: Resource[IO, Res] =
-      Resource.eval(IO.sleep(index * 500.millis)).flatMap(_ =>
-        global.getOrFailR[LazyState]())
+    def sharedResource: Resource[IO, Res] = {
+      global.getOrFailR[SequentialAccess]().flatMap { semRes =>
+        semRes.permit.flatMap { _ =>
+          global.getOrFailR[LazyState]()
+        }
+      }
+    }
 
     test("Lazy resources should be instantiated several times") { state =>
       state.getState(parallelWait = false).map {

--- a/modules/framework/cats/test/src-jvm/MetaJVM.scala
+++ b/modules/framework/cats/test/src-jvm/MetaJVM.scala
@@ -82,8 +82,9 @@ object MetaJVM {
            *   - Change the number of LazyAccessParallel suites in "global lazy
            *     resources (parallel)" test
            *
-           *   - Change the number below 3. Add another test to the
-           *     LazyAccessParallel spec below
+           *   - Change the number below
+           *
+           *   - Add another test to the LazyAccessParallel spec below
            *
            * You are very likely to face a very confusing non-deterministic
            * behaviour. Those numbers need to be kept in sync.


### PR DESCRIPTION
1. for LazyAccessParallel tests, we use CyclicBarrier to ensure that all 3 suites enter the assertions block at the same time - this will keep the lazy resource alive for long enough to be reused, hence satisfyingthe test
2. For LazyAccessSequential, we use a semaphore with 1 permit to make sure the tests are indeed sequentially executed and finalised before the next one starts. This helps testing that lazy resource is indeed reinstantiated on demand if the suite that originally created it has already finished

Closes #565 