### PR TITLE
RFC: matches and whenSuccess combinators

### DIFF
--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -53,6 +53,14 @@ The easiest way to construct expectactions is to call the `expect` macro, which 
   exists(Option(5))(n => expect(n > 3))
   ```
 
+- Use `matches` to assert that an expression matches a given pattern
+
+  ```scala mdoc:compile-only
+  matches(Option(4)) { case Some(x) =>
+    expect.eql(4, x)
+  }
+  ```
+
 - Use `expect.eql` for strict equality comparison (types that implement `Eq`
     typeclass) and string representation diffing (using `Show` typeclass, fall
     back to `toString` if no instance found) in

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -50,7 +50,7 @@ The easiest way to construct expectactions is to call the `expect` macro, which 
     expectations:
 
   ```scala mdoc:compile-only
-  exists(Option(5))(n => expect(n > 3)
+  exists(Option(5))(n => expect(n > 3))
   ```
 
 - Use `expect.eql` for strict equality comparison (types that implement `Eq`

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -61,6 +61,17 @@ The easiest way to construct expectactions is to call the `expect` macro, which 
   }
   ```
 
+- Use `whenSuccess` to assert that a structure with an error channel (like `Either`) is successful
+
+  ```scala mdoc:compile-only
+  val res: Either[String, Int] =
+    Right(4)
+  
+  whenSuccess(res) { n =>
+    expect.eql(4, n)
+  }
+  ```
+
 - Use `expect.eql` for strict equality comparison (types that implement `Eq`
     typeclass) and string representation diffing (using `Show` typeclass, fall
     back to `toString` if no instance found) in

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -217,7 +217,7 @@ object Expectations {
      *
      * @example
      *   {{{
-     *     matches(Option(4) { case Some(x) =>
+     *     matches(Option(4)) { case Some(x) =>
      *       expect.eql(4, x)
      *     }
      *   }}}

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -238,6 +238,19 @@ object Expectations {
     def inEach[L[_], A](la: L[A])(f: A => Expectations)(
         implicit L: Foldable[L]): Expectations = forEach(la)(f)
 
+    /**
+     * Checks that an `ApplicativeError` (like `Either`) is successful
+     *
+     * @example
+     *   {{{
+     *     val res: Either[String, Int] =
+     *       Right(4)
+     *
+     *     whenSuccess(res) { n =>
+     *       expect.eql(4, n)
+     *     }
+     *   }}}
+     */
     def whenSuccess[F[_], A, E](fa: F[A])(
         f: A => Expectations
     )(

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -238,6 +238,18 @@ object Expectations {
     def inEach[L[_], A](la: L[A])(f: A => Expectations)(
         implicit L: Foldable[L]): Expectations = forEach(la)(f)
 
+    def existsRight[F[_], A, E](fa: F[A])(
+        f: A => Expectations
+    )(
+        implicit pos: SourceLocation,
+        F: ApplicativeError[F, E],
+        G: Foldable[F],
+        E: Show[E] = Show.fromToString[E]): Expectations =
+      fa
+        .map(f)
+        .handleError(e => failure(e.show))
+        .foldLeft(failure("impossible?"))((_, x) => x)
+
     def verify(condition: Boolean, hint: String)(
         implicit pos: SourceLocation): Expectations =
       if (condition) success

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -248,7 +248,9 @@ object Expectations {
       fa
         .map(f)
         .handleError(e => failure("Expected success case, got: " + e.show))
-        .foldLeft(failure("impossible?"))((_, x) => x)
+        .foldLeft(failure(
+          "unexpected error case encountered after error handling"))((z, x) =>
+          z || x)
 
     def verify(condition: Boolean, hint: String)(
         implicit pos: SourceLocation): Expectations =

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -230,7 +230,7 @@ object Expectations {
       if (f.isDefinedAt(x))
         f(x)
       else
-        failure("Pattern did not match, got: " + A.show(x))
+        failure("Pattern did not match, got: " + x.show)
 
     /**
      * Alias for `forEach`
@@ -238,7 +238,7 @@ object Expectations {
     def inEach[L[_], A](la: L[A])(f: A => Expectations)(
         implicit L: Foldable[L]): Expectations = forEach(la)(f)
 
-    def existsRight[F[_], A, E](fa: F[A])(
+    def whenSuccess[F[_], A, E](fa: F[A])(
         f: A => Expectations
     )(
         implicit pos: SourceLocation,
@@ -247,7 +247,7 @@ object Expectations {
         E: Show[E] = Show.fromToString[E]): Expectations =
       fa
         .map(f)
-        .handleError(e => failure(e.show))
+        .handleError(e => failure("Expected success case, got: " + e.show))
         .foldLeft(failure("impossible?"))((_, x) => x)
 
     def verify(condition: Boolean, hint: String)(

--- a/modules/core/src/weaver/Expectations.scala
+++ b/modules/core/src/weaver/Expectations.scala
@@ -212,6 +212,27 @@ object Expectations {
       Expectations.Additive.unwrap(la.foldMap(a => Expectations.Additive(f(a))))
 
     /**
+     * Checks that a given expression matches a certain pattern; fails
+     * otherwise.
+     *
+     * @example
+     *   {{{
+     *     matches(Option(4) { case Some(x) =>
+     *       expect.eql(4, x)
+     *     }
+     *   }}}
+     */
+    def matches[A](x: A)(
+        f: PartialFunction[A, Expectations]
+    )(
+        implicit pos: SourceLocation,
+        A: Show[A] = Show.fromToString[A]): Expectations =
+      if (f.isDefinedAt(x))
+        f(x)
+      else
+        failure("Pattern did not match, got: " + A.show(x))
+
+    /**
      * Alias for `forEach`
      */
     def inEach[L[_], A](la: L[A])(f: A => Expectations)(

--- a/modules/framework/cats/test/src/ExpectationsTests.scala
+++ b/modules/framework/cats/test/src/ExpectationsTests.scala
@@ -74,7 +74,8 @@ object ExpectationsTests extends SimpleIOSuite {
       Left("bad")
 
     whenSuccess(good)(expect.eql(4, _)) and
-      not(whenSuccess(bad)(_ => failure("dead code")))
+      not(whenSuccess(bad)(_ =>
+        failure("unexpected run of success handler given failure payload")))
   }
 
 }

--- a/modules/framework/cats/test/src/ExpectationsTests.scala
+++ b/modules/framework/cats/test/src/ExpectationsTests.scala
@@ -66,4 +66,15 @@ object ExpectationsTests extends SimpleIOSuite {
     expect.same(0, 1)
   }
 
+  pureTest("exists right") {
+    val good: Either[String, Int] =
+      Right(4)
+
+    val bad: Either[String, Int] =
+      Left("bad")
+
+    existsRight(good)(expect.eql(4, _)) and
+      not(existsRight(bad)(_ => failure("dead code")))
+  }
+
 }

--- a/modules/framework/cats/test/src/ExpectationsTests.scala
+++ b/modules/framework/cats/test/src/ExpectationsTests.scala
@@ -52,6 +52,15 @@ object ExpectationsTests extends SimpleIOSuite {
       not(expect.same("bar", "foo"))
   }
 
+  pureTest("matches pattern") {
+    matches(Option(4)) { case Some(x) =>
+      expect.eql(4, x)
+    } and
+      not(matches(Option(4)) { case None =>
+        failure("dead code")
+      })
+  }
+
   pureTest("expect.same respects cats.kernel.Eq") {
     implicit val eqInt: Eq[Int] = Eq.allEqual
     expect.same(0, 1)

--- a/modules/framework/cats/test/src/ExpectationsTests.scala
+++ b/modules/framework/cats/test/src/ExpectationsTests.scala
@@ -66,15 +66,15 @@ object ExpectationsTests extends SimpleIOSuite {
     expect.same(0, 1)
   }
 
-  pureTest("exists right") {
+  pureTest("when success") {
     val good: Either[String, Int] =
       Right(4)
 
     val bad: Either[String, Int] =
       Left("bad")
 
-    existsRight(good)(expect.eql(4, _)) and
-      not(existsRight(bad)(_ => failure("dead code")))
+    whenSuccess(good)(expect.eql(4, _)) and
+      not(whenSuccess(bad)(_ => failure("dead code")))
   }
 
 }


### PR DESCRIPTION
Includes two independent proposals per #614

1) `matches` partial pattern match combinator
2) `existsRight` combinator for asserting `ApplicativeError`

Proposal 2 is more a strawman, I'm not confident in it at all. I had to also demand `Foldable`. I looked at `Bifoldable` briefly but I wasn't sure how to merge the two channels into one. Felt like that was describing two fully independent channels vs a disjoint union in an `ApplicativeError`