### PR TITLE
Fix `CheckConfig` usage in `Checkers` trait

### DIFF
--- a/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
@@ -205,7 +205,7 @@ trait Checkers {
     def shouldContinue(config: CheckConfig) = !shouldStop(config)
 
     def endResult(implicit loc: SourceLocation) = failure.getOrElse {
-      if (succeeded < checkConfig.minimumSuccessful)
+      if (succeeded < config.minimumSuccessful)
         Expectations.Helpers.failure(
           s"Discarded more inputs ($discarded) than allowed")
       else Expectations.Helpers.success

--- a/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
@@ -120,7 +120,7 @@ trait Checkers {
           (newStatus, newStatus)
         }
         .map(_._1)
-        .takeWhile(_.shouldContinue, takeFailure = true)
+        .takeWhile(_.shouldContinue(config), takeFailure = true)
         .takeRight(1) // getting the first error (which finishes the stream)
         .compile
         .last
@@ -197,12 +197,12 @@ trait Checkers {
         copy(failure = Some(failure))
       } else this
 
-    def shouldStop =
+    def shouldStop(config: CheckConfig) =
       failure.isDefined ||
-        succeeded >= checkConfig.minimumSuccessful ||
-        discarded >= checkConfig.maximumDiscarded
+        succeeded >= config.minimumSuccessful ||
+        discarded >= config.maximumDiscarded
 
-    def shouldContinue = !shouldStop
+    def shouldContinue(config: CheckConfig) = !shouldStop(config)
 
     def endResult(implicit loc: SourceLocation) = failure.getOrElse {
       if (succeeded < checkConfig.minimumSuccessful)

--- a/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
@@ -126,7 +126,7 @@ trait Checkers {
         .last
         .map { (x: Option[Status[A]]) =>
           x match {
-            case Some(status) => status.endResult
+            case Some(status) => status.endResult(config)
             case None         => Expectations.Helpers.success
           }
         }
@@ -204,12 +204,13 @@ trait Checkers {
 
     def shouldContinue(config: CheckConfig) = !shouldStop(config)
 
-    def endResult(implicit loc: SourceLocation) = failure.getOrElse {
-      if (succeeded < config.minimumSuccessful)
-        Expectations.Helpers.failure(
-          s"Discarded more inputs ($discarded) than allowed")
-      else Expectations.Helpers.success
-    }
+    def endResult(config: CheckConfig)(implicit loc: SourceLocation) =
+      failure.getOrElse {
+        if (succeeded < config.minimumSuccessful)
+          Expectations.Helpers.failure(
+            s"Discarded more inputs ($discarded) than allowed")
+        else Expectations.Helpers.success
+      }
   }
   private object Status {
     def start[T] = Status[T](0, 0, None)

--- a/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -53,7 +53,7 @@ object PropertyDogFoodTest extends IOSuite {
       events <- dogfood.runSuite(Meta.ParallelChecks).map(_._2)
       _      <- expect(events.size == 1).failFast
     } yield {
-      expect(events.headOption.get.duration() < 10000)
+      expect(events.headOption.get.duration() < 100000)
     }
   }
 

--- a/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -57,16 +57,16 @@ object PropertyDogFoodTest extends IOSuite {
     }
   }
 
-  test("Discarded counts should be accurate") { dogfood =>
-    expectErrorMessage(
-      s"Discarded more inputs (${Meta.DiscardedChecks.checkConfig.maximumDiscarded}) than allowed",
-      dogfood.runSuite(Meta.DiscardedChecks))
-  }
-
   test("Config can be overridden") { dogfood =>
     expectErrorMessage(
       s"Discarded more inputs (${Meta.ConfigOverrideChecks.configOverride.maximumDiscarded}) than allowed",
       dogfood.runSuite(Meta.ConfigOverrideChecks))
+  }
+
+  test("Discarded counts should be accurate") { dogfood =>
+    expectErrorMessage(
+      s"Discarded more inputs (${Meta.DiscardedChecks.checkConfig.maximumDiscarded}) than allowed",
+      dogfood.runSuite(Meta.DiscardedChecks))
   }
 
   def expectErrorMessage(
@@ -80,7 +80,6 @@ object PropertyDogFoodTest extends IOSuite {
         expect(log.contains(msg))
       }
     }
-
 }
 
 object Meta {
@@ -126,16 +125,6 @@ object Meta {
     }
   }
 
-  object DiscardedChecks extends DiscardedChecks {
-
-    override def partiallyAppliedForall: PartiallyAppliedForall = forall
-
-    override def checkConfig =
-      super.checkConfig.copy(minimumSuccessful = 100,
-                             // to avoid overcounting of discarded checks
-                             perPropertyParallelism = 1)
-  }
-
   object ConfigOverrideChecks extends DiscardedChecks {
 
     val configOverride =
@@ -146,4 +135,13 @@ object Meta {
       forall.withConfig(configOverride)
   }
 
+  object DiscardedChecks extends DiscardedChecks {
+
+    override def partiallyAppliedForall: PartiallyAppliedForall = forall
+
+    override def checkConfig =
+      super.checkConfig.copy(minimumSuccessful = 100,
+                             // to avoid overcounting of discarded checks
+                             perPropertyParallelism = 1)
+  }
 }


### PR DESCRIPTION
- Use overridden config in the stopping condition instead of the config from the base trait.
   Closes https://github.com/disneystreaming/weaver-test/issues/628.
- Fix upper bound in parallelisation test to match the description.