### PR TITLE
Use builder pattern for CheckConfig

### DIFF
--- a/modules/scalacheck/src/weaver/scalacheck/CheckConfig.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/CheckConfig.scala
@@ -1,18 +1,106 @@
 package weaver
 package scalacheck
 
-case class CheckConfig(
-    minimumSuccessful: Int,
-    maximumDiscardRatio: Int,
-    maximumGeneratorSize: Int,
-    perPropertyParallelism: Int,
-    initialSeed: Option[Long]
-) {
+import org.scalacheck.rng.Seed
+
+final class CheckConfig(
+    val minimumSuccessful: Int,
+    val maximumDiscardRatio: Int,
+    val maximumGeneratorSize: Int,
+    val perPropertyParallelism: Int,
+    val initialSeed: Option[Seed]) extends Product with Serializable {
   assert(maximumDiscardRatio >= 0)
   assert(maximumDiscardRatio <= 100)
   assert(minimumSuccessful > 0)
 
   def maximumDiscarded = minimumSuccessful * maximumDiscardRatio / 100
+
+  def withMinimumSuccessful(minimumSuccessful: Int) = new CheckConfig(
+    minimumSuccessful = minimumSuccessful,
+    maximumDiscardRatio = this.maximumDiscardRatio,
+    maximumGeneratorSize = this.maximumGeneratorSize,
+    perPropertyParallelism = this.perPropertyParallelism,
+    initialSeed = this.initialSeed
+  )
+
+  def withMaximumDiscardRatio(maximumDiscardRatio: Int) = new CheckConfig(
+    minimumSuccessful = this.minimumSuccessful,
+    maximumDiscardRatio = maximumDiscardRatio,
+    maximumGeneratorSize = this.maximumGeneratorSize,
+    perPropertyParallelism = this.perPropertyParallelism,
+    initialSeed = this.initialSeed
+  )
+
+  def withMaximumGeneratorSize(maximumGeneratorSize: Int) = new CheckConfig(
+    minimumSuccessful = this.minimumSuccessful,
+    maximumDiscardRatio = this.maximumDiscardRatio,
+    maximumGeneratorSize = maximumGeneratorSize,
+    perPropertyParallelism = this.perPropertyParallelism,
+    initialSeed = this.initialSeed
+  )
+
+  def withPerPropertyParallelism(perPropertyParallelism: Int) = new CheckConfig(
+    minimumSuccessful = this.minimumSuccessful,
+    maximumDiscardRatio = this.maximumDiscardRatio,
+    maximumGeneratorSize = this.maximumGeneratorSize,
+    perPropertyParallelism = perPropertyParallelism,
+    initialSeed = this.initialSeed
+  )
+
+  def withInitialSeed(initialSeed: Option[Seed]) = new CheckConfig(
+    minimumSuccessful = this.minimumSuccessful,
+    maximumDiscardRatio = this.maximumDiscardRatio,
+    maximumGeneratorSize = this.maximumGeneratorSize,
+    perPropertyParallelism = this.perPropertyParallelism,
+    initialSeed = initialSeed
+  )
+
+  override def toString: String = {
+    val b = new StringBuilder("CheckConfig(")
+    b.append(String.valueOf(this.minimumSuccessful))
+    b.append(", ")
+    b.append(String.valueOf(this.maximumDiscardRatio))
+    b.append(", ")
+    b.append(String.valueOf(this.maximumGeneratorSize))
+    b.append(", ")
+    b.append(String.valueOf(this.perPropertyParallelism))
+    b.append(", ")
+    b.append(String.valueOf(this.initialSeed))
+    b.append(")")
+    b.toString()
+  }
+
+  override def canEqual(obj: Any): Boolean =
+    obj != null && obj.isInstanceOf[CheckConfig]
+
+  override def equals(obj: Any): Boolean = canEqual(obj) && {
+    val other = obj.asInstanceOf[CheckConfig]
+    this.minimumSuccessful == other.minimumSuccessful && this.maximumDiscardRatio == other.maximumDiscardRatio && this.maximumGeneratorSize == other.maximumGeneratorSize &&
+    this.perPropertyParallelism == other.perPropertyParallelism && this.initialSeed == other.initialSeed
+  }
+
+  override def hashCode: Int = {
+    var code = 17 + "CheckConfig".##
+    code = 37 * code + this.minimumSuccessful.##
+    code = 37 * code + this.maximumDiscardRatio.##
+    code = 37 * code + this.maximumGeneratorSize.##
+    code = 37 * code + this.perPropertyParallelism.##
+    code = 37 * code + this.initialSeed.##
+    37 * code
+  }
+
+  override def productPrefix: String = "CheckConfig"
+
+  override def productArity: Int = 5
+
+  override def productElement(n: Int): Any = n match {
+    case 0 => this.minimumSuccessful
+    case 1 => this.maximumDiscardRatio
+    case 2 => this.maximumGeneratorSize
+    case 3 => this.perPropertyParallelism
+    case 4 => this.initialSeed
+    case n => throw new IndexOutOfBoundsException(n.toString)
+  }
 }
 
 object CheckConfig {
@@ -23,4 +111,16 @@ object CheckConfig {
     perPropertyParallelism = 10,
     initialSeed = None
   )
+
+  def apply(
+      minimumSuccessful: Int,
+      maximumDiscardRatio: Int,
+      maximumGeneratorSize: Int,
+      perPropertyParallelism: Int,
+      initialSeed: Option[Seed]): CheckConfig =
+    new CheckConfig(minimumSuccessful,
+                    maximumDiscardRatio,
+                    maximumGeneratorSize,
+                    perPropertyParallelism,
+                    initialSeed)
 }

--- a/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
@@ -136,7 +136,7 @@ trait Checkers {
       val initial = startSeed(
         Gen.Parameters.default
           .withSize(config.maximumGeneratorSize)
-          .withInitialSeed(config.initialSeed.map(Seed(_))))
+          .withInitialSeed(config.initialSeed))
 
       fs2.Stream.iterate(initial) {
         case (p, s) => (p, s.slide)

--- a/modules/scalacheck/test/src/weaver/scalacheck/CheckersTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/CheckersTest.scala
@@ -11,7 +11,7 @@ import org.scalacheck.Gen
 object CheckersTest extends SimpleIOSuite with Checkers {
 
   override def checkConfig: CheckConfig =
-    super.checkConfig.copy(perPropertyParallelism = 100)
+    super.checkConfig.withPerPropertyParallelism(100)
 
   test("universal") {
     forall(Gen.posNum[Int]) { a =>

--- a/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/test/src/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -9,6 +9,7 @@ import cats.syntax.all._
 import weaver.framework._
 
 import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
 
 object PropertyDogFoodTest extends IOSuite {
 
@@ -103,13 +104,16 @@ object Meta {
 
     override def checkConfig: CheckConfig =
       super.checkConfig
-        .copy(perPropertyParallelism = 100, minimumSuccessful = 100)
+        .withPerPropertyParallelism(100)
+        .withMinimumSuccessful(100)
   }
 
   object FailedChecks extends SimpleIOSuite with Checkers {
 
     override def checkConfig: CheckConfig =
-      super.checkConfig.copy(perPropertyParallelism = 1, initialSeed = Some(5L))
+      super.checkConfig
+        .withPerPropertyParallelism(1)
+        .withInitialSeed(Some(Seed(5L)))
 
     test("foobar") {
       forall { (x: Int) =>
@@ -128,8 +132,9 @@ object Meta {
   object ConfigOverrideChecks extends DiscardedChecks {
 
     val configOverride =
-      super.checkConfig.copy(minimumSuccessful = 200,
-                             perPropertyParallelism = 1)
+      super.checkConfig
+        .withMinimumSuccessful(200)
+        .withPerPropertyParallelism(1)
 
     override def partiallyAppliedForall: PartiallyAppliedForall =
       forall.withConfig(configOverride)
@@ -140,8 +145,10 @@ object Meta {
     override def partiallyAppliedForall: PartiallyAppliedForall = forall
 
     override def checkConfig =
-      super.checkConfig.copy(minimumSuccessful = 100,
-                             // to avoid overcounting of discarded checks
-                             perPropertyParallelism = 1)
+      super.checkConfig
+        .withMinimumSuccessful(100)
+        .withPerPropertyParallelism(
+          1
+        ) // to avoid overcounting of discarded checks
   }
 }


### PR DESCRIPTION
### What
* Implement `CheckConfig` using the builder pattern (tweaked the output of https://github.com/alexarchambault/data-class).
* This PR is a breaking change but hopefully the class can be extended in a backwards compatible way.

### Why
* Fix https://github.com/disneystreaming/weaver-test/issues/632.




