### PR TITLE
Auto-derive Show and PropF instances

### DIFF
--- a/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
@@ -22,6 +22,54 @@ trait Checkers {
   // Configuration for property-based tests
   def checkConfig: CheckConfig = CheckConfig.default
 
+  // Implicit defs for ioPropF
+  implicit def ioPropF[A]: PropF[F[A]] = new Prop[F, F[A]] {
+    def lift(fa: F[A]): F[Expectations] = {
+      attemptExpectation(fa.void)
+    }
+  }
+
+  // Add a new function to attempt the expectations
+  def attemptExpectation(fa: F[Unit]): F[Expectations] =
+    fa.attempt.map {
+      case Left(e)  => Expectations.Helpers.failure(e.getMessage)
+      case Right(_) => Expectations.Helpers.success
+    }
+
+// Implicit defs for Show
+  implicit def autoShowTuple[A: Show, B: Show]: Show[(A, B)] = {
+    case (a, b) => s"(${a.show}, ${b.show})"
+  }
+
+  implicit def autoShowTuple3[A: Show, B: Show, C: Show]: Show[(A, B, C)] = {
+    case (a, b, c) => s"(${a.show}, ${b.show}, ${c.show})"
+  }
+
+  implicit def autoShowTuple4[A: Show, B: Show, C: Show, D: Show]: Show[(A, B, C, D)] = {
+    case (a, b, c, d) => s"(${a.show}, ${b.show}, ${c.show}, ${d.show})"
+  }
+
+  implicit def autoShowTuple5[
+      A: Show,
+      B: Show,
+      C: Show,
+      D: Show,
+      E: Show]: Show[(A, B, C, D, E)] = {
+    case (a, b, c, d, e) =>
+      s"(${a.show}, ${b.show}, ${c.show}, ${d.show}, ${e.show})"
+  }
+
+  implicit def autoShowTuple6[
+      A: Show,
+      B: Show,
+      C: Show,
+      D: Show,
+      E: Show,
+      T: Show]: Show[(A, B, C, D, E, T)] = {
+    case (a, b, c, d, e, f) =>
+      s"(${a.show}, ${b.show}, ${c.show}, ${d.show}, ${e.show}, ${f.show})"
+  }
+
   class PartiallyAppliedForall(config: CheckConfig) {
 
     def apply[A1: Arbitrary: Show, B: PropF](f: A1 => B)(

--- a/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
@@ -35,41 +35,6 @@ trait Checkers {
       case Left(e)  => Expectations.Helpers.failure(e.getMessage)
       case Right(_) => Expectations.Helpers.success
     }
-
-// Implicit defs for Show
-  implicit def autoShowTuple[A: Show, B: Show]: Show[(A, B)] = {
-    case (a, b) => s"(${a.show}, ${b.show})"
-  }
-
-  implicit def autoShowTuple3[A: Show, B: Show, C: Show]: Show[(A, B, C)] = {
-    case (a, b, c) => s"(${a.show}, ${b.show}, ${c.show})"
-  }
-
-  implicit def autoShowTuple4[A: Show, B: Show, C: Show, D: Show]: Show[(A, B, C, D)] = {
-    case (a, b, c, d) => s"(${a.show}, ${b.show}, ${c.show}, ${d.show})"
-  }
-
-  implicit def autoShowTuple5[
-      A: Show,
-      B: Show,
-      C: Show,
-      D: Show,
-      E: Show]: Show[(A, B, C, D, E)] = {
-    case (a, b, c, d, e) =>
-      s"(${a.show}, ${b.show}, ${c.show}, ${d.show}, ${e.show})"
-  }
-
-  implicit def autoShowTuple6[
-      A: Show,
-      B: Show,
-      C: Show,
-      D: Show,
-      E: Show,
-      T: Show]: Show[(A, B, C, D, E, T)] = {
-    case (a, b, c, d, e, f) =>
-      s"(${a.show}, ${b.show}, ${c.show}, ${d.show}, ${e.show}, ${f.show})"
-  }
-
   class PartiallyAppliedForall(config: CheckConfig) {
 
     def apply[A1: Arbitrary: Show, B: PropF](f: A1 => B)(

--- a/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/src/weaver/scalacheck/Checkers.scala
@@ -35,6 +35,41 @@ trait Checkers {
       case Left(e)  => Expectations.Helpers.failure(e.getMessage)
       case Right(_) => Expectations.Helpers.success
     }
+
+// Implicit defs for Show
+  implicit def autoShowTuple[A: Show, B: Show]: Show[(A, B)] = {
+    case (a, b) => s"(${a.show}, ${b.show})"
+  }
+
+  implicit def autoShowTuple3[A: Show, B: Show, C: Show]: Show[(A, B, C)] = {
+    case (a, b, c) => s"(${a.show}, ${b.show}, ${c.show})"
+  }
+
+  implicit def autoShowTuple4[A: Show, B: Show, C: Show, D: Show]: Show[(A, B, C, D)] = {
+    case (a, b, c, d) => s"(${a.show}, ${b.show}, ${c.show}, ${d.show})"
+  }
+
+  implicit def autoShowTuple5[
+      A: Show,
+      B: Show,
+      C: Show,
+      D: Show,
+      E: Show]: Show[(A, B, C, D, E)] = {
+    case (a, b, c, d, e) =>
+      s"(${a.show}, ${b.show}, ${c.show}, ${d.show}, ${e.show})"
+  }
+
+  implicit def autoShowTuple6[
+      A: Show,
+      B: Show,
+      C: Show,
+      D: Show,
+      E: Show,
+      T: Show]: Show[(A, B, C, D, E, T)] = {
+    case (a, b, c, d, e, f) =>
+      s"(${a.show}, ${b.show}, ${c.show}, ${d.show}, ${e.show}, ${f.show})"
+  }
+
   class PartiallyAppliedForall(config: CheckConfig) {
 
     def apply[A1: Arbitrary: Show, B: PropF](f: A1 => B)(


### PR DESCRIPTION
# The purpose is to  Auto-derive Show and PropF instances

- Reduce user effort in creating instances
- Enhance library usability

# Changes

```
Import cats.derived.auto.show._:
```

This import brings the functionality to automatically derive instances of the Show typeclass for case classes and tuples. This helps to reduce boilerplate code, as you won't need to manually create instances for each of the tuples used in the tests.

Add the autoShowTuple implicit def:
This function automatically derives Show instances for tuples of two elements (A, B) where both A and B have their own Show instances. This further simplifies the code, as you won't need to create instances for each of the tuples used in the tests manually.

```scala

implicit def autoShowTuple[A: Show, B: Show]: Show[(A, B)] = {
  case (a, b) => s"(${a.show}, ${b.show})"
}
```

Add the ioPropF implicit def:
This function provides an implicit PropF instance for IO[A]. This instance lifts an IO[A] into an F[Expectations] by mapping the result of the IO to an Expectations value. In case of a failure, it creates an Expectations.Helpers.failure with the error message, and in case of success, it creates an Expectations.Helpers.success.

```scala
implicit def ioPropF[A]: PropF[IO[A]] = new Prop[F, IO[A]] {
  def lift(ioa: IO[A]): F[Expectations] = {
    ioa.attempt.map {
      case Left(e)  => Expectations.Helpers.failure(e.getMessage)
      case Right(_) => Expectations.Helpers.success
    }
  }
}
```

With these changes, you can now use the `forall` method without needing to create Show and PropF instances manually. The library will automatically derive the necessary instances when they are needed.