### PR TITLE
Grow output buffer when needed when reporting test outcomes (JS/Native)

### DIFF
--- a/modules/framework/cats/test/src-js-native/TestOutcomeEncodingTests.scala
+++ b/modules/framework/cats/test/src-js-native/TestOutcomeEncodingTests.scala
@@ -1,0 +1,40 @@
+package weaver
+package framework
+package test
+
+object TestOutcomeEncodingTests
+    extends FunSuite {
+
+  private val anOutcome =
+    TestOutcomeNative("suite-1", "test-1", 10, "verbosity goes here")
+
+  roundtripTest("even, small doubles for the duration",
+                anOutcome.copy(durationMs = 42))
+
+  roundtripTest("bigger doubles for the duration",
+                anOutcome.copy(durationMs = 50000))
+
+  roundtripTest("uneven doubles for the duration",
+                anOutcome.copy(durationMs = 42.57))
+
+  roundtripTest(
+    "Int.MaxValue duration",
+    anOutcome.copy(durationMs = Int.MaxValue)
+  )
+  roundtripTest(
+    "Double.MaxValue duration",
+    anOutcome.copy(durationMs = Double.MaxValue)
+  )
+
+  private def roundtripTest(name: TestName, input: TestOutcomeNative)(implicit
+  loc: SourceLocation) = {
+
+    test(name.copy(name = "Roundtrip test - " + name.name)) {
+      val encoded = TestOutcomeNative.encode(input)
+      val decoded = TestOutcomeNative.decode(encoded)
+
+      assert.same(input, decoded)
+    }
+  }
+
+}

--- a/modules/framework/cats/test/src/Meta.scala
+++ b/modules/framework/cats/test/src/Meta.scala
@@ -111,6 +111,22 @@ object Meta {
     }
   }
 
+  object ErroringWithLongPayload extends SimpleIOSuite {
+    override implicit protected def effectCompat: UnsafeRun[IO] =
+      SetTimeUnsafeRun
+
+    val smiles = ":)" * 1024
+
+    test("erroring with a long message: " + smiles) {
+      IO.raiseError(
+        CustomException(
+          "surfaced error",
+          withSnips = true
+        )
+      ).as(success)
+    }
+  }
+
   case class CustomException(
       str: String,
       causedBy: Exception = null,


### PR DESCRIPTION
Closes #724.